### PR TITLE
[Bug] Referential integrity is violated when the number of users exceeds maxPartLength in /rooms/invite 

### DIFF
--- a/src/service/rooms.js
+++ b/src/service/rooms.js
@@ -117,7 +117,7 @@ const inviteHandler = async (req, res) => {
       for (const userID of req.body.users) {
         let newUser = await userModel.findOne({ id: userID });
         if (!newUser) {
-          res.status(404).json({
+          res.status(400).json({
             error: "Rooms/invite : no corresponding user",
           });
           return;
@@ -128,13 +128,16 @@ const inviteHandler = async (req, res) => {
           });
           return;
         }
-        // if ((room.part.length+req.body.users.length)>room.maxPartLength){ // 초대할 사람 수가 방의 남은 자리 수를 초과하면 초대가 불가능합니다.
-        //   res.status(400).json({
-        //     error: "Room/invite : There are too many people to invite to the room",
-        //   });
-        //   return;
-        // }
         newUsers.push(newUser);
+      }
+
+      // 초대할 사람 수가 방의 남은 자리 수를 초과하면 초대가 불가능합니다.
+      if (room.part.length + req.body.users.length > room.maxPartLength) {
+        res.status(400).json({
+          error:
+            "Room/invite : There are too many people to invite to the room",
+        });
+        return;
       }
 
       for (let newUser of newUsers) {
@@ -175,11 +178,6 @@ const inviteHandler = async (req, res) => {
     res.send(room);
   } catch (error) {
     console.log(error);
-    if (error._message === "Room validation failed") {
-      res.status(400).json({
-        error: "Room/invite : the room is full",
-      });
-    }
     res.status(500).json({
       error: "Rooms/invite : internal server error",
     });


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #85.
/rooms/invite (방 초대 및 참여) API에서 방 인원 제한을 초과하는 요청이 들어왔을 때 해당 방의 part 배열에 해당 사용자가 추가되는 것은 스키마의 유효성 검증에 의해 막히지만 해당 사용자의 rooms 배열에는 새로운 방이 추가되는 문제가 있었습니다.

이전에 주석 처리하였던 방 인원 비교 코드를 다시 주석 해제해 일단 해당 버그는 해결하였습니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? y
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

- 없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- /rooms/invite 요청을 처리하는 데 걸리는 시간 측정하기: 요청을 처리하는 데 지연이 발생한다면 한 사용자의 요청이 끝나기 전에 다른 사용자가 요청을 할 가능성이 있고, 그런 예외를 처리하기 위한 이슈를 개설할 필요가 있다고 생각합니다.
