### PR TITLE
[Bug] Log file is not generated properly in Windows

### DIFF
--- a/src/modules/logger.js
+++ b/src/modules/logger.js
@@ -7,7 +7,7 @@ const customFormat = format.printf(({ level, message, timestamp }) => {
   return `${timestamp} [${level}]: ${message}`;
 });
 
-const datePattern = "YYYY-MM-DD-HH:MM";
+const datePattern = "YYYY-MM-DD-HH-MM";
 
 // Create a new logger
 const logger = createLogger({


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #91 
winston의 file transport로써 사용되어서 매일 로그 파일을 새로 생성해주는 dailyRotateFileTransport 모듈에 인자로 넘긴 datePattern에 허용되지 않는 문자(":")가 있던 문제를 수정했습니다.
관련 이슈: https://github.com/winstonjs/winston-daily-rotate-file/issues/278

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? n

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="348" alt="무제" src="https://user-images.githubusercontent.com/46402016/182664313-5bb03edd-4aae-41fd-9893-90d57c41a09f.png">

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
