### PR TITLE
#101 create api versions

### DIFF
--- a/app.js
+++ b/app.js
@@ -29,6 +29,7 @@ app.use(require("response-time")(logAPIAccess));
 app.use("/auth", require("./src/route/auth"));
 app.use("/json/logininfo", require("./src/route/logininfo"));
 app.use("/users", require("./src/route/users"));
+app.use("/rooms/v2", require("./src/route/rooms.v2"));
 app.use("/rooms", require("./src/route/rooms"));
 app.use("/chats", require("./src/route/chats"));
 app.use("/static", require("./src/route/static"));

--- a/src/db/patterns.js
+++ b/src/db/patterns.js
@@ -1,6 +1,8 @@
 module.exports = {
   room: {
     name: RegExp("^[A-Za-z0-9가-힣ㄱ-ㅎㅏ-ㅣ,.?! _-]{1,20}$"),
+    from: RegExp("^[A-Za-z0-9가-힣 -]{1,20}$"),
+    to: RegExp("^[A-Za-z0-9가-힣 -]{1,20}$"),
   },
   user: {
     nickname: RegExp("^[A-Za-z가-힣ㄱ-ㅎㅏ-ㅣ0-9-_ ]{3,25}$"),

--- a/src/route/docs/rooms.v2.md
+++ b/src/route/docs/rooms.v2.md
@@ -9,8 +9,16 @@
 Room {
   _id: ObjectId, //ObjectID
   name: String, // 1~50글자로 구성되며 영어 대소문자, 숫자, 한글, "-", ",", ".", "?", "!", "_"로만 이루어져야 함.
-  from: String, // 출발지
-  to: String, // 도착지
+  from: {
+    _id: ObjectId // 출발지 document의 ObjectId
+    koName: String, // 출발지의 한국어 명칭
+    enName: String, // 출발지의 영어 명칭
+  }, 
+  to: {
+    _id: ObjectId // 도착지 document의 ObjectId
+    koName: String, // 도착지의 한국어 명칭
+    enName: String, // 도착지의 영어 명칭
+  }, 
   time: String(ISO 8601), // ex) 방 출발 시각. '2022-01-12T13:58:20.180Z'
   part: [
     {
@@ -61,10 +69,10 @@ ID를 parameter로 받아 해당 ID의 room의 정보 출력
 
 ```javascript
 {
-  name : String,
-  from : String,
-  to : String,
-  time : Date,
+  name : String, // 방 이름. 문서 상단에 명시된 규칙을 만족시켜야 함
+  from : ObjectId, // 출발지 Document의 ObjectId
+  to : ObjectId, // 도착지 Document의 ObjectId
+  time : Date, // 방 출발 시각. 현재 이후여야 함.
   part? : String[]  // 방 사람들의 ObjectId. 따라서 빈 배열로 요청하시면 됩니다.
 }
 ```
@@ -88,8 +96,8 @@ room의 ID와 user들의 ID list를 받아 해당 room의 participants에 추가
 
 ```javascript
 {
-    roomId : ObjectID,
-    users : List[userID], //user.id (not ObjectID)
+    roomId : ObjectId, // 초대 혹은 참여하려는 방 Document의 ObjectId
+    users : [String(userId)], // user.id (not ObjectID)
 }
 ```
 
@@ -157,11 +165,11 @@ room의 ID와 user들의 ID list를 받아 해당 room의 participants에 추가
 
 ```javascript
 {
-    name : String,
-    from : String,
-    to : String,
-    time : Date,
-    part : String[]
+  name : String, // 방 이름. 문서 상단에 명시된 규칙을 만족시켜야 함
+  from : ObjectId, // 출발지 Document의 ObjectId
+  to : ObjectId, // 도착지 Document의 ObjectId
+  time : Date, // 방 출발 시각. 현재 이후여야 함.
+  part? : String[]  // 방 사람들의 ObjectId. 따라서 빈 배열로 요청하시면 됩니다.
 }
 ```
 
@@ -187,7 +195,7 @@ ID를 받아 해당 ID의 room을 제거
 
 ```javascript
 {
-  id: String,
+  id: ObjectId, // 삭제할 방 Document의 ObjectId
   isDeleted: true
 }
 ```

--- a/src/route/rooms.js
+++ b/src/route/rooms.js
@@ -22,13 +22,27 @@ router.post(
   "/create",
   [
     body("name").matches(patterns.room.name),
+    body("from").matches(patterns.room.from),
+    body("to").matches(patterns.room.to),
+    body("time").isISO8601(),
+    body("maxPartLength").isInt({ min: 1, max: 4 }),
+  ],
+  validator,
+  roomHandlers.createHandler
+);
+
+// JSON으로 받은 정보로 방을 생성한다.
+router.post(
+  "/v2/create",
+  [
+    body("name").matches(patterns.room.name),
     body("from").isMongoId(),
     body("to").isMongoId(),
     body("time").isISO8601(),
     body("maxPartLength").isInt({ min: 1, max: 4 }),
   ],
   validator,
-  roomHandlers.createHandler
+  roomHandlers.v2CreateHandler
 );
 
 // 새로운 사용자를 방에 참여시킨다.
@@ -60,12 +74,25 @@ router.get(
   "/search",
   [
     query("name").optional().matches(patterns.room.name),
+    body("from").matches(patterns.room.from),
+    body("to").matches(patterns.room.to),
+    query("time").optional().isISO8601(),
+  ],
+  validator,
+  roomHandlers.searchHandler
+);
+
+// 조건(이름, 출발지, 도착지, 날짜)에 맞는 방들을 모두 반환한다.
+router.get(
+  "/v2/search",
+  [
+    query("name").optional().matches(patterns.room.name),
     query("from").optional().isMongoId(),
     query("to").optional().isMongoId(),
     query("time").optional().isISO8601(),
   ],
   validator,
-  roomHandlers.searchHandler
+  roomHandlers.v2SearchHandler
 );
 
 // 로그인된 사용자의 모든 방들을 반환한다.

--- a/src/route/rooms.v2.js
+++ b/src/route/rooms.v2.js
@@ -4,7 +4,7 @@ const validator = require("../middleware/validator");
 const patterns = require("../db/patterns");
 
 const router = express.Router();
-const roomHandlers = require("../service/rooms");
+const roomHandlers = require("../service/rooms.v2");
 
 // 라우터 접근 시 로그인 필요
 router.use(require("../middleware/auth"));
@@ -22,8 +22,8 @@ router.post(
   "/create",
   [
     body("name").matches(patterns.room.name),
-    body("from").matches(patterns.room.from),
-    body("to").matches(patterns.room.to),
+    body("from").isMongoId(),
+    body("to").isMongoId(),
     body("time").isISO8601(),
     body("maxPartLength").isInt({ min: 1, max: 4 }),
   ],
@@ -60,8 +60,8 @@ router.get(
   "/search",
   [
     query("name").optional().matches(patterns.room.name),
-    query("from").optional().matches(patterns.room.from),
-    query("to").optional().matches(patterns.room.to),
+    query("from").optional().isMongoId(),
+    query("to").optional().isMongoId(),
     query("time").optional().isISO8601(),
   ],
   validator,
@@ -71,6 +71,9 @@ router.get(
 // 로그인된 사용자의 모든 방들을 반환한다.
 router.get("/searchByUser/", roomHandlers.searchByUserHandler);
 
+// THE ROUTES BELOW ARE ONLY FOR TEST
+router.get("/getAllRoom", roomHandlers.getAllRoomHandler);
+
 // 해당 룸의 요청을 보낸 유저의 정산을 완료로 처리한다.
 router.post(
   "/:id/settlement",
@@ -78,11 +81,6 @@ router.post(
   validator,
   roomHandlers.idSettlementHandler
 );
-
-// THE ROUTES BELOW ARE ONLY FOR TEST
-router.get("/getAllRoom", roomHandlers.getAllRoomHandler);
-
-router.get("/removeAllRoom", roomHandlers.removeAllRoomHandler);
 
 // json으로 수정할 값들을 받아 방의 정보를 수정합니다.
 // request JSON
@@ -100,14 +98,6 @@ router.post(
   ],
   validator,
   roomHandlers.idEditHandler
-);
-
-// FIXME: 방장만 삭제 가능.
-router.get(
-  "/:id/delete",
-  param("id").isMongoId(),
-  validator,
-  roomHandlers.idDeleteHandler
 );
 
 module.exports = router;

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -89,16 +89,8 @@ const createHandler = async (req, res) => {
 };
 
 const infoHandler = async (req, res) => {
-  const userId = req.userId;
-  if (!userId) {
-    res.status(403).json({
-      error: "Rooms/info : not logged in",
-    });
-    return;
-  }
-
   try {
-    const user = await userModel.findOne({ id: userId });
+    const user = await userModel.findOne({ id: req.userId });
 
     let room = await roomModel.findById(req.query.id);
     if (room) {
@@ -128,8 +120,8 @@ const infoHandler = async (req, res) => {
 
 const inviteHandler = async (req, res) => {
   try {
-    let user = await userModel.findOne({ id: req.userId });
-    let room = await roomModel.findById(req.body.roomId);
+    const user = await userModel.findOne({ id: req.userId });
+    const room = await roomModel.findById(req.body.roomId);
     if (!user) {
       res.status(400).json({
         error: "Rooms/invite : Bad request",
@@ -220,8 +212,8 @@ const abortHandler = async (req, res) => {
   };
 
   try {
-    let user = await userModel.findOne({ id: req.userId });
-    let room = await roomModel.findById(req.body.roomId);
+    const user = await userModel.findOne({ id: req.userId });
+    const room = await roomModel.findById(req.body.roomId);
     if (!user) {
       res.status(400).json({
         error: "Rooms/abort : Bad request",
@@ -359,7 +351,6 @@ const searchHandler = async (req, res) => {
       .exec();
     res.json(rooms.map((room) => formatSettlement(room)));
   } catch (err) {
-    console.error(err);
     res.status(500).json({
       error: "Rooms/search : Internal server error",
     });
@@ -367,16 +358,9 @@ const searchHandler = async (req, res) => {
 };
 
 const searchByUserHandler = async (req, res) => {
-  const userId = req.userId;
-  if (!userId) {
-    res.status(403).json({
-      error: "Rooms/searchByUser : not logged in",
-    });
-  }
-
   try {
     const user = await userModel
-      .findOne({ id: userId })
+      .findOne({ id: req.userId })
       .populate({
         path: "room",
         populate: roomPopulateQuery,


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #101
백엔드에서 특정 API가 변경되었을 때 해당 API에 v2 태그를 붙여 기존 API가 계속 호환되도록 조치했습니다.
예를 들어, /rooms/create의 입력값이 바뀌었다면
- 입력값이 바뀐 새 API는 /rooms/v2/create
- 기존 API는 /rooms/create 를 통해 사용 가능합니다.
빠른 개발을 위해 기존 API는 프론트엔드의 main 브랜치에서 사용하지 않는 대로 바로 삭제하려고 합니다.

처음엔 location 스키마 변경에 영향을 받는 API의 수가 적을 거라고 생각해서 기존 API와 새 API를 한 파일에 작업했는데, 생각보다 바뀌어야 하는 API의 수가 많아서 기존 API와 새 API를 두 개의 파일로 분리하였습니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? y
- Needs more than 10 minutes for review? y
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
<img width="728" alt="기존 /rooms/search API 요청 결과" src="https://user-images.githubusercontent.com/46402016/183977880-8a2c2378-c538-4523-874a-8bbbbd60e80e.png">

**기존 /rooms/search API 요청 결과**

<img width="726" alt="새 /rooms/v2/search API 요청 결과" src="https://user-images.githubusercontent.com/46402016/183977899-92f4cef3-66be-4373-8ace-ccf96bbcf29d.png">

**새 /rooms/v2/search API 요청 결과**

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
