### PR TITLE
Add: set default timezone to Seoul

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,7 @@
 {
     "ignore": ["node_modules/*"],
     "env": {
+        "TZ": "Asia/Seoul",
         "NODE_ENV": "development"
     } 
 }

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
   },
   "scripts": {
     "start": "npx nodemon app.js",
-    "test": "cross-env NODE_ENV=test mocha --recursive --reporter spec --exit",
-    "serve": "cross-env NODE_ENV=production node app.js"
+    "test": "cross-env TZ='Asia/Seoul' NODE_ENV=test mocha --recursive --reporter spec --exit",
+    "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node app.js"
   },
   "author": "sparcs/taxi",
   "license": "MIT"


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #104 
백엔드 서버의 시간대를 "Asia/Seoul"로 설정합니다.
이를 명시적으로 설정해야 하는 이유는 도커에서 Node 컨테이너를 생성할 때 기본 시간대가 UTC로 설정되어 있기 때문입니다.
Node는 process.env.TZ 환경변수에 설정된 시간대로 Date 객체의 기본 시간대를 결정하므로, TZ 환경변수를 서울로 설정하면 문제를 해결할 수 있습니다.
참조: https://www.ibm.com/docs/ko/cics-ts/5.6?topic=properties-setting-time-zone-nodejs-application

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? n

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->


<img width="614" alt="스크린샷 2022-08-12 오전 4 59 20" src="https://user-images.githubusercontent.com/46402016/184228679-99abd4f2-2b75-4805-a6c7-f818f3144d72.png">
Timezone을 UTC로 설정한 다음 한국시간 기준 2022-08-12일 오전 4시 59분 20초에 서버를 실행한 모습

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
