### PR TITLE
Fix: 24시간 후 계산하는 방식 변경

### DIFF
--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -285,16 +285,6 @@ const searchHandler = async (req, res) => {
     else return false;
   };
 
-  const getTomorrow5am = (date) => {
-    const tomorrowDate = new Date(date);
-    // If the minTime is over 12 AM
-    if (tomorrowDate.getUTCHours() >= 20) {
-      tomorrowDate.setUTCDate(tomorrowDate.getUTCDate() + 1);
-    }
-    tomorrowDate.setUTCHours(20, 0, 0, 0);
-    return tomorrowDate;
-  };
-
   try {
     const { name, from, to, time } = req.query;
     let fromOid = null;
@@ -340,7 +330,9 @@ const searchHandler = async (req, res) => {
       });
     }
 
-    const maxTime = getTomorrow5am(minTime);
+    const maxTime = new Date(minTime).setTime(
+      minTime.getTime() + 24 * 60 * 60 * 1000
+    );
     query.time = { $gte: minTime, $lt: maxTime };
 
     const rooms = await roomModel


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #109 

날짜만 검색조건에 주어졌을 때 쿼리 생성 중 24시간 이후(`maxTime`) 계산 방식을 변경했습니다.
- 기존: `getTomorrow5am` 함수 이용
- 이후: `Date.setTime` 이용

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? y
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

![image](https://user-images.githubusercontent.com/34625313/184493086-26f09a55-8076-4c5d-85ba-7e42bb32923e.png)


