### PR TITLE
#114 [bug] Express & Socket.io sessions are not synchronized automatically

### DIFF
--- a/src/route/chats.socket.js
+++ b/src/route/chats.socket.js
@@ -1,6 +1,7 @@
 const { getLoginInfo, joinChatRoom, leaveChatRoom } = require("../auth/login");
 const { roomModel, userModel, chatModel } = require("../db/mongo");
 const validator = require("validator");
+const logger = require("../modules/logger");
 
 class IllegalArgumentsException {
   constructor() {
@@ -50,8 +51,8 @@ const emitChatEvent = async (io, roomId, chat) => {
       }
     }
     io.to(`chatRoom-${roomId}`).emit("chats-receive", { chat });
-  } catch (e) {
-    console.log(e);
+  } catch (err) {
+    logger.error(err);
     return;
   }
 };
@@ -128,7 +129,8 @@ const ioListeners = (io, socket) => {
           chats: await transformChatsForRoom(chats),
         });
       }
-    } catch (e) {
+    } catch (err) {
+      logger.error(err);
       io.to(socket.id).emit("chats-join", { err: true });
     }
   });
@@ -151,7 +153,8 @@ const ioListeners = (io, socket) => {
       // leave chat room
       leaveChatRoom({ session: session });
       socket.leave(`chatRoom-${roomId}`);
-    } catch (e) {
+    } catch (err) {
+      logger.error(err);
       io.to(socket.id).emit("chats-disconnect", { err: true });
     }
   });
@@ -174,7 +177,8 @@ const ioListeners = (io, socket) => {
         authorId: myUser._id,
       });
       io.to(socket.id).emit("chats-send", { done: true });
-    } catch (e) {
+    } catch (err) {
+      logger.error(err);
       io.to(socket.id).emit("chats-send", { err: true });
     }
   });
@@ -207,7 +211,8 @@ const ioListeners = (io, socket) => {
       } else {
         return io.to(socket.id).emit("chats-load", { err: true });
       }
-    } catch (e) {
+    } catch (err) {
+      logger.error(err);
       io.to(socket.id).emit("chats-load", { err: true });
     }
   });

--- a/src/route/chats.socket.js
+++ b/src/route/chats.socket.js
@@ -11,7 +11,7 @@ class IllegalArgumentsException {
   }
 }
 
-/** @global
+/** @constant {{path: string, select: string}[]}
  * 쿼리를 통해 얻은 Chat Document를 populate할 설정값을 정의합니다.
  */
 const chatPopulateOption = [
@@ -113,7 +113,7 @@ const ioListeners = (io, socket) => {
       // join chat room
       joinChatRoom({ session: session }, socket.id, roomId);
       socket.join(`chatRoom-${roomId}`);
-      session.save(); // Socket.io 세션의 변경 사항을 Express 세션에 반영.
+      // session.save(); // Socket.io 세션의 변경 사항을 Express 세션에 반영.
 
       const amount = 30;
       const chats = await chatModel

--- a/src/route/chats.socket.js
+++ b/src/route/chats.socket.js
@@ -59,7 +59,7 @@ const emitChatEvent = async (io, roomId, chat) => {
 
 /**
  * Chat Object의 array가 주어졌을 때 클라이언트에서 처리하기 편한 형태로 Chat Object를 가공합니다.
- * @param {[Mongoose.Model]} chats - Chats Document에 lean과 populate(chatPopulateOption)을 차례로 적용한 Chat Object의 배열입니다.
+ * @param {[Object]} chats - Chats Document에 lean과 populate(chatPopulateOption)을 차례로 적용한 Chat Object의 배열입니다.
  * @return {Promise} {type: String, authorId: String, authorName: String, authorProfileUrl: String, content: string, time: Date}로 이루어진 chat 객체의 배열입니다.
  */
 const transformChatsForRoom = async (chats) => {

--- a/src/route/chats.socket.js
+++ b/src/route/chats.socket.js
@@ -118,6 +118,7 @@ const ioListeners = (io, socket) => {
       // join chat room
       joinChatRoom({ session: session }, socket.id, roomId);
       socket.join(`chatRoom-${roomId}`);
+      session.save(); // Socket.io 세션의 변경 사항을 Express 세션에 반영.
 
       const amount = 30;
       const chats = await chatModel

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -7,7 +7,8 @@ const { emitChatEvent } = require("../route/chats.socket");
 const { leaveChatRoom } = require("../auth/login");
 const logger = require("../modules/logger");
 
-/** 쿼리를 통해 얻은 Room Document를 populate할 설정값을 정의합니다.
+/** @global
+ * 쿼리를 통해 얻은 Room Document를 populate할 설정값을 정의합니다.
  */
 const roomPopulateOption = [
   { path: "part", select: "_id id name nickname profileImageUrl" },

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -7,7 +7,7 @@ const { emitChatEvent } = require("../route/chats.socket");
 const { leaveChatRoom } = require("../auth/login");
 const logger = require("../modules/logger");
 
-/** @global
+/** @constant {{path: string, select: string, populate?: {path: string, select: string}}[]}
  * 쿼리를 통해 얻은 Room Document를 populate할 설정값을 정의합니다.
  */
 const roomPopulateOption = [


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #113 
`src/route/chats.socket.js`에서 Promise constructor에 async 함수가 들어가는 패턴의 `chatsForRoom` 함수를 Promise constructor 없이 똑같은 기능을 하도록 수정하였습니다.

It fixes #114
Socket.io에서 사용자 session에 chatRoomId 속성을 설정해도 express의 session에 해당 값이 바로 저장되지 않는 문제가 발생하여, `session.save()`를 호출하여 명시적으로 Socket.io 세션과 express의 세션을 동기화했습니다.


# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? y
- Needs more than 10 minutes for review? y
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

![화면 기록 2022-08-18 오전 3 46 46](https://user-images.githubusercontent.com/46402016/185219150-d0b6cf76-6ec8-424d-a6fe-79047f6c4636.gif)
- 수정 후, 브라우저에서 채팅방에 처음 들어갔을 때에도 사진이 잘 전송되었습니다. 수정한 코드를 주석 처리하면 문제가 다시 발생합니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- `/static` 라우터 제거: 서버에서 정적 파일을 호스팅할 필요가 없어졌습니다.
- 개발용 `/rooms`, `/users` API 제거: admin 페이지로 대체 가능합니다. https://github.com/sparcs-kaist/taxi-back/pull/100#discussion_r945340482
- **auth.replace 라우터 테스트케이스 고치기**: 로그인 시도 url이 `/auth/try`여야 하는데 테스트 코드에서는 `/auth/sparcssso`로 적혀 있어서 로그인 성공 여부가 제대로 테스트되지 않는 문제가 발생했습니다. 어제 발생한 #115 도 CI 단계에서 걸렸었어야 했는데 테스트 코드를 잘못 짜서 그러지 못했어요 ㄷ