### PR TITLE
Add: update settlement schema and settlement APIs

### DIFF
--- a/src/db/mongo.js
+++ b/src/db/mongo.js
@@ -24,9 +24,14 @@ const userSchema = Schema({
   isAdmin: { type: Boolean, default: false }, //관리자 여부
 });
 
-const settlementSchema = Schema({
-  studentId: { type: Schema.Types.ObjectId, ref: "User", required: true },
-  isSettlement: { type: Boolean, required: true },
+const participantSchema = Schema({
+  user: { type: Schema.Types.ObjectId, ref: "User", required: true },
+  settlementStatus: {
+    type: String,
+    required: true,
+    enum: ["not-departed", "paid", "send-required", "sent"],
+    default: "not-departed",
+  },
 });
 
 const roomSchema = Schema({
@@ -35,27 +40,19 @@ const roomSchema = Schema({
   to: { type: Schema.Types.ObjectId, ref: "Location", required: true },
   time: { type: Date, required: true }, // 출발 시간
   part: {
-    type: [{ type: Schema.Types.ObjectId, ref: "User" }],
+    type: [participantSchema],
     validate: [
       function (value) {
         return value.length <= this.maxPartLength;
       },
     ],
-  }, // 참여 멤버
+  }, // 참여 멤버 및 정산 여부
   madeat: { type: Date, required: true }, // 생성 날짜
-  settlement: {
-    type: [settlementSchema],
-    default: [
-      {
-        isSettlement: false,
-      },
-    ],
-  },
   settlementTotal: { type: Number, default: 0, required: true },
   isOver: { type: Boolean, default: false, required: true },
   maxPartLength: { type: Number, require: true, default: 4 },
-  //FIXME: 결제 예정자, 정산 여부 (웹페이지에서 이를 어떻게 처리할 것인지 추가 논의가 필요함)
 });
+
 const locationSchema = Schema({
   enName: { type: String, required: true },
   koName: { type: String, required: true },
@@ -64,7 +61,7 @@ const locationSchema = Schema({
 });
 const chatSchema = Schema({
   roomId: { type: Schema.Types.ObjectId, ref: "Room", required: true },
-  type: { type: String }, // 메시지 종류 (text|in|out|s3img)
+  type: { type: String, enum: ["text", "in", "out", "s3img"] }, // 메시지 종류
   authorId: { type: Schema.Types.ObjectId, ref: "User", required: true }, // 작성자 id
   content: { type: String, default: "" },
   time: { type: Date, required: true },

--- a/src/route/chats.socket.js
+++ b/src/route/chats.socket.js
@@ -113,7 +113,7 @@ const ioListeners = (io, socket) => {
       // join chat room
       joinChatRoom({ session: session }, socket.id, roomId);
       socket.join(`chatRoom-${roomId}`);
-      // session.save(); // Socket.io 세션의 변경 사항을 Express 세션에 반영.
+      session.save(); // Socket.io 세션의 변경 사항을 Express 세션에 반영.
 
       const amount = 30;
       const chats = await chatModel

--- a/src/route/docs/rooms.v2.md
+++ b/src/route/docs/rooms.v2.md
@@ -75,7 +75,7 @@ Room {
       name: String, // 참여 중인 사용자 이름
       nickname: String, // 참여 중인 사용자 닉네임
       profileImageUrl: String, // 프로필 사진 url 
-      isSettlement: String, //해당 사용자의 정산이 완료됐는지 여부("not-departed" | "paid" | "send-required" | "sent") (주의: rooms/search에서는 isSettlement 속성을 반환하지 않음(undefined를 반환함).
+      isSettlement: String, //해당 사용자의 정산 상태 (주의: rooms/search에서는 isSettlement 속성을 반환하지 않음(undefined를 반환함).
     }
   ], 
   maxPartLength: Number(2~4), //방의 최대 인원 수
@@ -85,6 +85,13 @@ Room {
   __v: Number, // 문서 버전. mongoDB 내부적으로 사용됨.
 }
 ```
+
+`isSettlement` 속성은 아래 네 가지 값들 중 하나를 가진다.
+
+1. `"not-departed"` :  아무도 결제/정산하지 않은 상태
+2. `"paid"` : 택시비를 결제한 참가가 "결제하기" 버튼을 누르면 해당 참가자에게 설정되는 정산 상태.
+3. `"send-required"` : 특정 참가자가 "결제하기" 버튼을 눌렀을 때 그 방의 나머지 참가자에게 설정되는 정산 상태.
+4. `"sent"` : 정산 상태가`"send-required"`인 사용자가 "정산하기" 버튼을 눌렀을 때 그 사용자에게 설정되는 정산 상태.
 
 ## Available endpoints
 

--- a/src/route/docs/rooms.v2.md
+++ b/src/route/docs/rooms.v2.md
@@ -1,4 +1,51 @@
-## `/rooms`
+# `/rooms` API
+
+## Table of contents
+
+- [`/rooms` API](#rooms-api)
+  - [Table of contents](#table-of-contents)
+  - [Description](#description)
+  - [Available endpoints](#available-endpoints)
+    - [`info/` **(GET)**](#info-get)
+      - [URL parameters](#url-parameters)
+      - [Response](#response)
+      - [Errors](#errors)
+    - [`/create` **(POST)**](#create-post)
+      - [POST request form](#post-request-form)
+      - [Errors](#errors-1)
+      - [Response](#response-1)
+    - [`/join` (POST)](#join-post)
+      - [request JSON form](#request-json-form)
+      - [Errors](#errors-2)
+    - [`/search` **(GET)**](#search-get)
+      - [URL parameters](#url-parameters-1)
+      - [Response](#response-2)
+      - [Errors](#errors-3)
+    - [`/searchByUser` **(GET)**](#searchbyuser-get)
+      - [URL parameters](#url-parameters-2)
+      - [Response](#response-3)
+      - [Errors](#errors-4)
+    - [`/:id/commitPayment` **(POST)**](#idcommitpayment-post)
+      - [URL Parameters](#url-parameters-3)
+      - [Response](#response-4)
+      - [Errors](#errors-5)
+    - [`/:id/settlement/` **(POST)**](#idsettlement-post)
+      - [URL Parameters](#url-parameters-4)
+      - [Response](#response-5)
+      - [Errors](#errors-6)
+    - [`/:id/edit/` **(POST)** **(for dev)**](#idedit-post-for-dev)
+      - [URL Parameters](#url-parameters-5)
+      - [POST request form](#post-request-form-1)
+      - [Response](#response-6)
+      - [Errors](#errors-7)
+    - [`/getAllRoom` **(GET)** (for dev)](#getallroom-get-for-dev)
+    - [`/removeAllRoom` **(GET)** (for dev)](#removeallroom-get-for-dev)
+    - [`/:id/delete/` **(GET)** **(for dev)**](#iddelete-get-for-dev)
+      - [URL Parameters](#url-parameters-6)
+      - [Response](#response-7)
+      - [Errors](#errors-8)
+
+## Description
 
 - 방 생성/수정/삭제/조회 기능을 지원하는 API.
 - 로그인된 상태에서만 접근 가능
@@ -28,7 +75,7 @@ Room {
       name: String, // 참여 중인 사용자 이름
       nickname: String, // 참여 중인 사용자 닉네임
       profileImageUrl: String, // 프로필 사진 url 
-      isSettlement: Boolean, //해당 사용자의 정산이 완료됐는지 여부 (주의: rooms/search에서는 isSettlement 속성을 반환하지 않음(undefined를 반환함).
+      isSettlement: String, //해당 사용자의 정산이 완료됐는지 여부("not-departed" | "paid" | "send-required" | "sent") (주의: rooms/search에서는 isSettlement 속성을 반환하지 않음(undefined를 반환함).
     }
   ], 
   maxPartLength: Number(2~4), //방의 최대 인원 수
@@ -38,6 +85,8 @@ Room {
   __v: Number, // 문서 버전. mongoDB 내부적으로 사용됨.
 }
 ```
+
+## Available endpoints
 
 ### `info/` **(GET)**
 
@@ -143,8 +192,8 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 
 ```javascript
 {
-  ongoing: [Room], //이미 출발한 방
-  done: [Room], //아직 출발 안 한 방
+  ongoing: [Room], // 정산이 완료되지 않은 방 (방의 isDone 속성이 false인 방)
+  done: [Room], // 정산이 완료된 방 (방의 isDone 속성이 true인 방)
 }
 ```
 
@@ -153,10 +202,52 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 - 403 "not logged in"
 - 500 "internal server error"
 
+
+### `/:id/commitPayment` **(POST)**
+
+- ID를 받아 해당 방에 요청을 보낸 유저를 결제자로 처리
+- 방의 part 배열에서 요청을 보낸 유저의 isSettlement 속성을 `paid`로 설정하고, 나머지 유저들의 isSettlement 속성을 `"send-required"`로 설정함.
+
+#### URL Parameters
+
+- id : 정산할 room의 ID
+
+#### Response
+
+- 멤버들의 정산정보가 반영된 방의 정보
+
+#### Errors
+
+- 400 "Bad request": 로그인이 되어있지 않은 경우
+- 404 "cannot find settlement info": 사용자가 참여 중인 방이 아니거나, 이미 다른 사람이 결제자인 경우
+- 500 "internal server error"
+
+
+
+### `/:id/settlement/` **(POST)**
+
+- ID를 받아 해당 방에 요청을 보낸 유저의 정산을 완료로 처리
+- 방의 part 배열에서 요청을 보낸 유저의 isSettlement 속성을 `send-required`에서 `"sent"`로 변경함.
+- 방에 참여한 멤버들이 모두 정산완료를 하면 방의 `isDone` 속성이 `true`로 변경되며, 과거 방으로 취급됨
+
+#### URL Parameters
+
+- id : 정산할 room의 ID
+
+#### Response
+
+- 멤버들의 정산정보가 반영된 방의 정보
+
+#### Errors
+
+- 400 "Bad request" : 로그인이 되어있지 않은 경우
+- 404 "cannot find settlement info": 사용자가 참여중인 방이 아니거나, 사용자가 결제를 했거나 이미 정산한 경우
+- 500 "internal server error"
+
 ### `/:id/edit/` **(POST)** **(for dev)**
 
 - ID와 수정할 데이터를 JSON으로 받아 해당 ID의 room을 수정
-- 주의 : 주어진 데이터로 그 방 데이터를 모두 덮어씌움, 특정 property를 주지 않으면 Undefined로 씌움
+- 방에 참여중인 사용자만 정보를 수정할 수 있음.
 - 프론트엔드에서 쓰일 일은 없어 보임.
 
 #### URL Parameters
@@ -171,8 +262,7 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
   from? : ObjectId, // 출발지 Document의 ObjectId
   to? : ObjectId, // 도착지 Document의 ObjectId
   time? : Date, // 방 출발 시각. 현재 이후여야 함.
-  part? : String[]  // 방 사람들의 ObjectId. 따라서 빈 배열로 요청하시면 됩니다.
-  maxPartLength?: Number(2~4), // 방의 최대 인원 수.
+  maxPartLength?: Number(2~4), // 방의 최대 인원 수. 현재 참여 인원수보다 크거나 같은 값이어야 함.
 }
 ```
 
@@ -185,6 +275,14 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 - 400 "Bad request"
 - 404 "id does not exist"
 - 500 "internal server error"
+
+### `/getAllRoom` **(GET)** (for dev)
+
+모든 방 가져옴
+
+### `/removeAllRoom` **(GET)** (for dev)
+
+모든 방 삭제
 
 ### `/:id/delete/` **(GET)** **(for dev)**
 
@@ -207,47 +305,3 @@ ID를 받아 해당 ID의 room을 제거
 
 - 404 "ID does not exist"
 - 500 "Internal server error"
-
-### `/searchByUser` **(GET)**
-
-로그인된 사용자가 참여 중인 room들을 반환한다.
-
-#### URL parameters
-
-없음.
-
-#### Response
-
-- 해당 방의 정보
-
-#### Errors
-
-- 403 "not logged in"
-- 500 "internal server error"
-
-### `/getAllRoom` **(GET)** (for dev)
-
-모든 방 가져옴
-
-### `/removeAllRoom` **(GET)** (for dev)
-
-모든 방 삭제
-
-### `/:id/settlement/` **(POST)**
-
-- ID를 받아 해당 룸의 요청을 보낸 유저의 정산을 완료로 처리
-- 방에 참여한 멤버들이 모두 정산완료를 하면 방은 과거방으로 변경됨
-
-#### URL Parameters
-
-- id : 정산할 room의 ID
-
-#### Response
-
-- 멤버들의 정산정보가 반영된 방의 정보
-
-#### Errors
-
-- 400 "Bad request"
-- 404 "cannot find settlement info"
-- 500 "internal server error"

--- a/src/route/docs/rooms.v2.md
+++ b/src/route/docs/rooms.v2.md
@@ -213,6 +213,7 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 ### `/:id/commitPayment` **(POST)**
 
 - ID를 받아 해당 방에 요청을 보낸 유저를 결제자로 처리
+- 이미 출발한 방(현재 시각이 출발 시각 이후인 경우)에 대해서만 요청을 처리함
 - 방의 part 배열에서 요청을 보낸 유저의 isSettlement 속성을 `paid`로 설정하고, 나머지 유저들의 isSettlement 속성을 `"send-required"`로 설정함.
 
 #### URL Parameters
@@ -226,7 +227,7 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 #### Errors
 
 - 400 "Bad request": 로그인이 되어있지 않은 경우
-- 404 "cannot find settlement info": 사용자가 참여 중인 방이 아니거나, 이미 다른 사람이 결제자인 경우
+- 404 "cannot find settlement info": 사용자가 참여 중인 방이 아니거나, 이미 다른 사람이 결제자이거나, 아직 방이 출발하지 않은 경우
 - 500 "internal server error"
 
 

--- a/src/route/docs/rooms.v2.md
+++ b/src/route/docs/rooms.v2.md
@@ -17,33 +17,36 @@
     - [`/join` (POST)](#join-post)
       - [request JSON form](#request-json-form)
       - [Errors](#errors-2)
+    - [`/abort` (POST)](#abort-post)
+      - [request JSON form](#request-json-form-1)
+      - [Errors](#errors-3)
     - [`/search` **(GET)**](#search-get)
       - [URL parameters](#url-parameters-1)
       - [Response](#response-2)
-      - [Errors](#errors-3)
+      - [Errors](#errors-4)
     - [`/searchByUser` **(GET)**](#searchbyuser-get)
       - [URL parameters](#url-parameters-2)
       - [Response](#response-3)
-      - [Errors](#errors-4)
+      - [Errors](#errors-5)
     - [`/:id/commitPayment` **(POST)**](#idcommitpayment-post)
       - [URL Parameters](#url-parameters-3)
       - [Response](#response-4)
-      - [Errors](#errors-5)
+      - [Errors](#errors-6)
     - [`/:id/settlement/` **(POST)**](#idsettlement-post)
       - [URL Parameters](#url-parameters-4)
       - [Response](#response-5)
-      - [Errors](#errors-6)
+      - [Errors](#errors-7)
     - [`/:id/edit/` **(POST)** **(for dev)**](#idedit-post-for-dev)
       - [URL Parameters](#url-parameters-5)
       - [POST request form](#post-request-form-1)
       - [Response](#response-6)
-      - [Errors](#errors-7)
+      - [Errors](#errors-8)
     - [`/getAllRoom` **(GET)** (for dev)](#getallroom-get-for-dev)
     - [`/removeAllRoom` **(GET)** (for dev)](#removeallroom-get-for-dev)
     - [`/:id/delete/` **(GET)** **(for dev)**](#iddelete-get-for-dev)
       - [URL Parameters](#url-parameters-6)
       - [Response](#response-7)
-      - [Errors](#errors-8)
+      - [Errors](#errors-9)
 
 ## Description
 
@@ -147,6 +150,7 @@ ID를 parameter로 받아 해당 ID의 room의 정보 출력
 ### `/join` (POST)
 
 room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용자를 추가한다.
+아직 출발하지 않은 방에만 참여할 수 있다.
 
 #### request JSON form
 
@@ -159,10 +163,32 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 #### Errors
 
 - 400 "Bad request"
-- 400 "no corresponding room"
 - 400 "The room is full"
+- 400 "The room has already departed"
+- 404 "no corresponding room"
 - 409 "{userID} Already in room"
 - 500 "internal server error"
+
+### `/abort` (POST)
+
+room의 ID를 받아 해당 room의 참가자 목록에서 요청을 보낸 사용자를 삭제한다.
+출발했지만 정산이 완료되지 않은 방에서는 나갈 수 없다.
+
+#### request JSON form
+
+```javascript
+{
+    roomId : ObjectId, // 초대 혹은 참여하려는 방 Document의 ObjectId
+}
+```
+
+#### Errors
+
+- 400 "Bad request"
+- 400 "cannot exit room. Settlement is not done"
+- 404 "no corresponding room"
+- 500 "internal server error"
+
 
 ### `/search` **(GET)**
 
@@ -180,6 +206,7 @@ room의 ID를 받아 해당 room의 참가자 목록에 요청을 보낸 사용�
 #### Response
 
 조건에 맞는 방**들**의 정보: `Room[]`
+조건에 일치하는 방이 없더라도 빈 배열을 반환함.
 
 #### Errors
 

--- a/src/route/docs/rooms.v2.md
+++ b/src/route/docs/rooms.v2.md
@@ -78,13 +78,13 @@ Room {
       name: String, // 참여 중인 사용자 이름
       nickname: String, // 참여 중인 사용자 닉네임
       profileImageUrl: String, // 프로필 사진 url 
-      isSettlement: String, //해당 사용자의 정산 상태 (주의: rooms/search에서는 isSettlement 속성을 반환하지 않음(undefined를 반환함).
+      isSettlement: String, //해당 사용자의 정산 상태 (주의: rooms/search에서는 isSettlement 속성을 반환하지 않고 undefined를 반환함).
     }
   ], 
   maxPartLength: Number(2~4), //방의 최대 인원 수
   madeat: String(ISO 8601), // ex) 방 생성 시각. '2022-01-12T13:58:20.180Z'
-  settlementTotal: Number(2~4), // 정산이 완료된 사용자 수
-  isOver: Boolean, // 해당 방의 정산이 완료됐는지 여부(완료 시 true)
+  settlementTotal: Number(2~4), // 정산이 완료된 사용자 수 (주의: rooms/search에서는 settlementTotal 속성을 반환하지 않고 undefined를 반환함).
+  isOver: Boolean, // 해당 방의 정산이 완료됐는지 여부(완료 시 true) (주의: rooms/search에서는 isOver 속성을 반환하지 않고 undefined를 반환함).
   __v: Number, // 문서 버전. mongoDB 내부적으로 사용됨.
 }
 ```

--- a/src/route/rooms.v2.js
+++ b/src/route/rooms.v2.js
@@ -95,6 +95,9 @@ router.post(
 // request JSON
 // name, from, to, time, part
 // FIXME: req.body.users 검증할 때 SSO ID 규칙 반영하기
+/**
+ * @todo Unused -> Remove
+ */
 router.post(
   "/:id/edit",
   [

--- a/src/route/rooms.v2.js
+++ b/src/route/rooms.v2.js
@@ -4,11 +4,12 @@
 
 const express = require("express");
 const { query, param, body } = require("express-validator");
+const router = express.Router();
+
+const roomHandlers = require("../service/rooms.v2");
 const validator = require("../middleware/validator");
 const patterns = require("../db/patterns");
-
-const router = express.Router();
-const roomHandlers = require("../service/rooms.v2");
+const setTimestamp = require("../middleware/setTimestamp");
 
 // 라우터 접근 시 로그인 필요
 router.use(require("../middleware/auth"));
@@ -41,6 +42,7 @@ router.post(
   "/join",
   [body("roomId").isMongoId()],
   validator,
+  setTimestamp,
   roomHandlers.joinHandler
 );
 
@@ -52,6 +54,7 @@ router.post(
   "/abort",
   body("roomId").isMongoId(),
   validator,
+  setTimestamp,
   roomHandlers.abortHandler
 );
 
@@ -76,6 +79,7 @@ router.post(
   "/:id/commitPayment",
   param("id").isMongoId(),
   validator,
+  setTimestamp,
   roomHandlers.commitPaymentByIdHandler
 );
 

--- a/src/route/rooms.v2.js
+++ b/src/route/rooms.v2.js
@@ -72,18 +72,20 @@ router.get(
 // 로그인된 사용자의 모든 방들을 반환한다.
 router.get("/searchByUser/", roomHandlers.searchByUserHandler);
 
+router.post(
+  "/:id/commitPayment",
+  param("id").isMongoId(),
+  validator,
+  roomHandlers.commitPaymentByIdHandler
+);
+
 // 해당 룸의 요청을 보낸 유저의 정산을 완료로 처리한다.
 router.post(
   "/:id/settlement",
   param("id").isMongoId(),
   validator,
-  roomHandlers.idSettlementHandler
+  roomHandlers.settlementByIdHandler
 );
-
-// THE ROUTES BELOW ARE ONLY FOR TEST
-router.get("/getAllRoom", roomHandlers.getAllRoomHandler);
-
-router.get("/removeAllRoom", roomHandlers.removeAllRoomHandler);
 
 // json으로 수정할 값들을 받아 방의 정보를 수정합니다.
 // request JSON
@@ -96,20 +98,30 @@ router.post(
     body("from").optional().isMongoId(),
     body("to").optional().isMongoId(),
     body("time").optional().isISO8601(),
-    body("part").isArray(),
-    body("part.*").optional().isLength({ min: 1, max: 30 }).isAlphanumeric(),
-    body("maxPartLength").isInt({ min: 2, max: 4 }),
+    body("maxPartLength").optional().isInt({ min: 2, max: 4 }),
   ],
   validator,
-  roomHandlers.idEditHandler
+  roomHandlers.editByIdHandler
 );
 
-// FIXME: 방장만 삭제 가능.
+/**
+ * @todo Unused -> Remove
+ */
+router.get("/getAllRoom", roomHandlers.getAllRoomHandler);
+
+/**
+ * @todo Unused -> Remove
+ */
+router.get("/removeAllRoom", roomHandlers.removeAllRoomHandler);
+
+/**
+ * @todo Unused -> Remove
+ */
 router.get(
   "/:id/delete",
   param("id").isMongoId(),
   validator,
-  roomHandlers.idDeleteHandler
+  roomHandlers.deleteByIdHandler
 );
 
 module.exports = router;

--- a/src/service/rooms.js
+++ b/src/service/rooms.js
@@ -1,3 +1,7 @@
+/**
+ * @todo 바뀐 roomSchema에 대응하기. 더 이상 안 쓰는 코드들이니까 완벽하게 짤 필요는 없을 것 같다.
+ */
+
 const { roomModel, locationModel, userModel } = require("../db/mongo");
 const { emitChatEvent } = require("../route/chats.socket");
 const { leaveChatRoom } = require("../auth/login");

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -454,6 +454,9 @@ const settlementByIdHandler = async (req, res) => {
   }
 };
 
+/**
+ * @todo Unused -> Remove
+ */
 const editByIdHandler = async (req, res) => {
   const { name, from, to, time, maxPartLength } = req.body;
   // 수정할 값이 주어지지 않은 경우

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -31,13 +31,13 @@ const formatSettlement = (roomObject, includeSettlement = true) => {
   roomObject.part = roomObject.part.map((participantSubDocument) => {
     const { _id, name, nickname, profileImageUrl } =
       participantSubDocument.user;
-    const { settlementStatus: isSettlement } = participantSubDocument;
+    const { settlementStatus } = participantSubDocument;
     return {
       _id,
       name,
       nickname,
       profileImageUrl,
-      isSettlement: includeSettlement ? isSettlement : undefined,
+      isSettlement: includeSettlement ? settlementStatus : undefined,
     };
   });
   roomObject.settlementTotal = includeSettlement

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -185,7 +185,6 @@ const joinHandler = async (req, res) => {
  * @todo 삭제할 유저 인덱스 더 쉽게 파악하기
  */
 const abortHandler = async (req, res) => {
-  const time = Date.now();
   const isOvertime = (room, time) => {
     if (new Date(room.time) <= time) return true;
     else return false;
@@ -203,14 +202,6 @@ const abortHandler = async (req, res) => {
     if (!room) {
       res.status(404).json({
         error: "Rooms/abort : no corresponding room",
-      });
-      return;
-    }
-
-    // 방이 이미 출발한 경우, 400 오류를 반환합니다.
-    if (req.timestamp >= room.time) {
-      res.status(400).json({
-        error: "Room/join : The room has already departed",
       });
       return;
     }
@@ -234,8 +225,8 @@ const abortHandler = async (req, res) => {
       return;
     } else {
       // 방의 출발시간이 지나고 정산이 되지 않으면 나갈 수 없음
-      if (isOvertime(room, time) && !room.isOver) {
-        res.status(403).json({
+      if (isOvertime(room, req.timestamp) && !room.isOver) {
+        res.status(400).json({
           error: "Rooms/info : cannot exit room. Settlement is not done",
         });
         return;

--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -40,6 +40,10 @@ const formatSettlement = (roomObject, includeSettlement = true) => {
       isSettlement: includeSettlement ? isSettlement : undefined,
     };
   });
+  roomObject.settlementTotal = includeSettlement
+    ? roomObject.settlementTotal
+    : undefined;
+  roomObject.isOver = includeSettlement ? roomObject.isOver : undefined;
   return roomObject;
 };
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #119 
- 채팅 헤더의 "결제하기" 버튼을 눌렀을 때 해당 방의 정산 담당자를 해당 유저로 설정하는 기능을 구현했습니다.
- 프론트엔드에 전달되는 정산 상태를 `true | false`에서 `"not-departed" | "paid" | "send-required" | "sent"`로 변경했습니다.
- 1. `"not-departed"` :  아무도 결제/정산하지 않은 상태
- 2. `"paid"` : 택시비를 결제한 참가가 "결제하기" 버튼을 누르면 해당 참가자에게 설정되는 정산 상태.
- 3. `"send-required"` : 특정 참가자가 "결제하기" 버튼을 눌렀을 때 그 방의 나머지 참가자에게 설정되는 정산 상태.
- 4. `"sent"` : 정산 상태가`"send-required"`인 사용자가 "정산하기" 버튼을 눌렀을 때 그 사용자에게 설정되는 정산 상태.

그 외에도, `/rooms/edit`에서 참조하는 roomModel의 스키마를 고치던 중, `/rooms/edit`에서 두 문제를 발견하여 수정했습니다.
- 특정 방에 참여중이지 않은 사용자도 해당 방의 정보를 수정할 수 있음.
- 방의 최대 인원수(`maxPartLength`)를 현재 방에 참여중인 인원수보다 더 작게 설정할 수 있음.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? y
- Needs more than 10 minutes for review? y
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

- 없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 안쓰는 API 제거하기 https://github.com/sparcs-kaist/taxi-back/issues/106
