### PR TITLE
Fix: fix isDeparted not included in Room object

### DIFF
--- a/src/service/rooms.v2.js
+++ b/src/service/rooms.v2.js
@@ -27,7 +27,11 @@ const roomPopulateOption = [
  * @param {Boolean} includeSettlement - 반환 결과에 정산 정보를 포함할 지 여부로, 기본값은 true입니다.
  * @return {Object} 정산 여부가 위와 같이 가공되고 isDeparted 속성이 추가된 Room Object가 반환됩니다.
  */
-const formatSettlement = (roomObject, includeSettlement = true) => {
+const formatSettlement = (
+  roomObject,
+  includeSettlement = true,
+  timestamp = Date.now()
+) => {
   roomObject.part = roomObject.part.map((participantSubDocument) => {
     const { _id, name, nickname, profileImageUrl } =
       participantSubDocument.user;
@@ -44,6 +48,8 @@ const formatSettlement = (roomObject, includeSettlement = true) => {
     ? roomObject.settlementTotal
     : undefined;
   roomObject.isOver = includeSettlement ? roomObject.isOver : undefined;
+  roomObject.isDeparted =
+    new Date(roomObject.time) < new Date(timestamp) ? true : false;
   return roomObject;
 };
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #121 
room API에서 `isDeparted` 속성을 반환하지 않는 문제를 수정합니다.
#119 를 해결하는 도중 누락했습니다. 죄송합니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? y

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
