### PR TITLE
Refactor: handle exception if kaist info is not provided

### DIFF
--- a/src/service/auth.js
+++ b/src/service/auth.js
@@ -11,17 +11,17 @@ const Client = require("../auth/sparcsso");
 const client = new Client(security.sparcssso?.id, security.sparcssso?.key);
 
 const transUserData = (userData) => {
+  const kaistInfo = userData.kaist_info ? JSON.parse(userData.kaist_info) : {};
   const info = {
     id: userData.uid,
     sid: userData.sid,
     name: userData.first_name + userData.last_name,
     facebook: userData.facebook_id || "",
     twitter: userData.twitter_id || "",
-    kaist: JSON.parse(userData.kaist_info)?.ku_std_no || "",
+    kaist: kaistInfo?.ku_std_no || "",
     sparcs: userData.sparcs_id || "",
     email: userData.email,
   };
-
   return info;
 };
 


### PR DESCRIPTION
Co-authored-by: 14KGun <geon6757@kaist.ac.kr>

# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #128 
`kaist_info`가 SSO로부터 주어지지 않을 때 JSON.parse 함수를 바로 사용할 수 없는 문제를 해결합니다.

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? n

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
