### PR TITLE
Include name in /json/loginInfo/detail

### DIFF
--- a/src/modules/modifyProfile.js
+++ b/src/modules/modifyProfile.js
@@ -84,7 +84,16 @@ const generateProfileImageUrl = () => {
   return `default/${defaultProfile[ridx]}`;
 };
 
+// 사용자의 이름과 성을 받아, 한글인지 영어인지에 따라 전체 이름을 반환합니다.
+const getFullUsername = (firstName, lastName) => {
+  const koPattern = new RegExp("[가-힣]+");
+  if (koPattern.test(firstName) && koPattern.test(lastName))
+    return `${lastName}${firstName}`;
+  else return `${firstName} ${lastName}`;
+};
+
 module.exports = {
   generateNickname,
   generateProfileImageUrl,
+  getFullUsername,
 };

--- a/src/service/auth.js
+++ b/src/service/auth.js
@@ -15,7 +15,7 @@ const transUserData = (userData) => {
   const info = {
     id: userData.uid,
     sid: userData.sid,
-    name: userData.first_name + userData.last_name,
+    name: `${userData.last_name} ${userData.first_name}`,
     facebook: userData.facebook_id || "",
     twitter: userData.twitter_id || "",
     kaist: kaistInfo?.ku_std_no || "",

--- a/src/service/auth.js
+++ b/src/service/auth.js
@@ -4,6 +4,7 @@ const { getLoginInfo, logout, login } = require("../auth/login");
 const {
   generateNickname,
   generateProfileImageUrl,
+  getFullUsername,
 } = require("../modules/modifyProfile");
 
 // SPARCS SSO
@@ -15,7 +16,7 @@ const transUserData = (userData) => {
   const info = {
     id: userData.uid,
     sid: userData.sid,
-    name: `${userData.last_name} ${userData.first_name}`,
+    name: getFullUsername(userData.first_name, userData.last_name),
     facebook: userData.facebook_id || "",
     twitter: userData.twitter_id || "",
     kaist: kaistInfo?.ku_std_no || "",

--- a/src/service/logininfo.js
+++ b/src/service/logininfo.js
@@ -12,7 +12,7 @@ const detailHandler = (req, res) => {
   if (user.id) {
     userModel.findOne(
       { id: user.id },
-      "_id id nickname withdraw ban joinat agreeOnTermsOfService subinfo email profileImageUrl",
+      "_id name nickname id withdraw ban joinat agreeOnTermsOfService subinfo email profileImageUrl",
       (err, result) => {
         if (err) res.json({ err: true });
         else if (!result) res.json({ err: true });
@@ -20,6 +20,7 @@ const detailHandler = (req, res) => {
           res.json({
             oid: result._id,
             id: result.id,
+            name: result.name,
             nickname: result.nickname,
             withdraw: result.withdraw,
             ban: result.ban,

--- a/test/logininfo.js
+++ b/test/logininfo.js
@@ -101,6 +101,7 @@ describe("detail info handler", function () {
           withdraw: result.withdraw,
           ban: result.ban,
           joinat: result.joinat,
+          name: result.name,
           agreeOnTermsOfService: result.agreeOnTermsOfService,
           subinfo: result.subinfo,
           email: result.email,


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #132 
/json/loginInfo/detail API에서 사용자 이름을 반환합니다.
SPARCS SSO 로그인 시 사용자 이름을 자연스러워 보이게 변경합니다.  e.g.) `"JEONGSANG"` -> `"SANG JEONG"`

# Extra info <!-- Answer 'y' or 'n' -->

- Needs more than 2 reviewers? n
- Needs more than 10 minutes for review? n
- Needs to execute in order to review? n

# Images <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
<img width="348" alt="스크린샷 2022-09-13 오후 10 18 57" src="https://user-images.githubusercontent.com/46402016/189911575-3ac1cd65-a57d-4b17-a1aa-b5d22e144d92.png">

- Postman 결과

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
