### PR TITLE
#137 dockerignore 추가

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+/node_modules
+.env.test
+.env.production
+.env.development
+.DS_store
+*.code-workspace
+*.swp
+/logs/*.log
+
+# AdminJS 관련 디렉토리
+.adminjs


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #137 

`.dockerignore`을 추가하여 local에서 도커 이미지 빌드 단계에사 `node_modules`, `.env`와 같은 파일들이 같이 `COPY`되는 것을 막습니다.
