### PR TITLE
#251 [Bug] AWS_S3_BUCKET_NAME not injected into security.aws.s3Url

### DIFF
--- a/security.js
+++ b/security.js
@@ -18,7 +18,7 @@ module.exports = {
     s3BucketName: process.env.AWS_S3_BUCKET_NAME, // required
     s3Url:
       process.env.AWS_S3_URL ||
-      "https://${process.env.AWS_S3_BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com", // optional
+      `https://${process.env.AWS_S3_BUCKET_NAME}.s3.ap-northeast-2.amazonaws.com`, // optional
   },
   jwtSecretKey: process.env.JWT_SECRET_KEY,
   appUriScheme: process.env.APP_URI_SCHEME,

--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -195,6 +195,12 @@ const sendMessageByTokens = async (tokens, type, title, body, icon, link) => {
           link: link || "/",
         },
       },
+      android: {
+        notification: {
+          icon: icon || "/icons-512.png",
+          imageUrl: icon || "/icons-512.png",
+        },
+      },
     };
     const { responses, failureCount } = await getMessaging().sendMulticast(
       message

--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -233,6 +233,11 @@ const sendMessageByTopic = async (topic, type, title, body, icon, link) => {
   try {
     const message = {
       topic,
+      data: {
+        url: link || "/",
+        icon: icon || "/icons-512.png",
+        click_action: "FLUTTER_NOTIFICATION_CLICK",
+      },
       notification: {
         title,
         body,
@@ -243,6 +248,12 @@ const sendMessageByTopic = async (topic, type, title, body, icon, link) => {
         },
         fcm_options: {
           link: link || "/",
+        },
+      },
+      android: {
+        notification: {
+          icon: icon || "/icons-512.png",
+          imageUrl: icon || "/icons-512.png",
         },
       },
     };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #251
`security.aws.s3Url` 변수에 S3 버킷 이름 환경변수가 주입되지 않는 문제를 해결합니다.

It closes #252 
Flutter 기기에서 백그라운드 알림 수신이 가능하도록 알림 전송 시 메시지 페이로드에 `android` 옵션을 추가합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="607" alt="스크린샷 2023-03-22 오전 3 52 04" src="https://user-images.githubusercontent.com/46402016/226711970-31aeaa75-c8b6-4cf6-9d80-80112a3aeeb3.png">
기뻐서 우는 중

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- FCM 해치웠나..?
