### PR TITLE
#254 FCM 메시지 payload의 title과 body를 data로 이동

### DIFF
--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -98,7 +98,6 @@ const removeExpiredTokens = async (deviceTokens, fcmResponses) => {
     deviceTokens.map(async (deviceToken, index) => {
       try {
         // FCM device token이 유효하지 않아 메시지 전송에 실패한 경우, 해당 device token을 DB에서 삭제합니다.
-        logger.info(fcmResponses[index].error.code);
         if (
           fcmResponses[index].error.code ===
           "messaging/registration-token-not-registered"

--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -98,6 +98,7 @@ const removeExpiredTokens = async (deviceTokens, fcmResponses) => {
     deviceTokens.map(async (deviceToken, index) => {
       try {
         // FCM device token이 유효하지 않아 메시지 전송에 실패한 경우, 해당 device token을 DB에서 삭제합니다.
+        logger.info(fcmResponses[index].error.code);
         if (
           fcmResponses[index].error.code ===
           "messaging/registration-token-not-registered"
@@ -107,6 +108,7 @@ const removeExpiredTokens = async (deviceTokens, fcmResponses) => {
         }
         return false;
       } catch (err) {
+        logger.info(err);
         return false;
       }
     })
@@ -179,21 +181,11 @@ const sendMessageByTokens = async (tokens, type, title, body, icon, link) => {
     const message = {
       tokens,
       data: {
+        title,
+        body,
         url: link || "/",
         icon: icon || "/icons-512.png",
         click_action: "FLUTTER_NOTIFICATION_CLICK",
-      },
-      notification: {
-        title,
-        body,
-      },
-      webpush: {
-        notification: {
-          icon: icon || "/icons-512.png",
-        },
-        fcm_options: {
-          link: link || "/",
-        },
       },
       android: {
         notification: {
@@ -234,21 +226,11 @@ const sendMessageByTopic = async (topic, type, title, body, icon, link) => {
     const message = {
       topic,
       data: {
+        title,
+        body,
         url: link || "/",
         icon: icon || "/icons-512.png",
         click_action: "FLUTTER_NOTIFICATION_CLICK",
-      },
-      notification: {
-        title,
-        body,
-      },
-      webpush: {
-        notification: {
-          icon: icon || "/icons-512.png",
-        },
-        fcm_options: {
-          link: link || "/",
-        },
       },
       android: {
         notification: {

--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -186,12 +186,6 @@ const sendMessageByTokens = async (tokens, type, title, body, icon, link) => {
         icon: icon || "/icons-512.png",
         click_action: "FLUTTER_NOTIFICATION_CLICK",
       },
-      android: {
-        notification: {
-          icon: icon || "/icons-512.png",
-          imageUrl: icon || "/icons-512.png",
-        },
-      },
     };
     const { responses, failureCount } = await getMessaging().sendMulticast(
       message
@@ -230,12 +224,6 @@ const sendMessageByTopic = async (topic, type, title, body, icon, link) => {
         url: link || "/",
         icon: icon || "/icons-512.png",
         click_action: "FLUTTER_NOTIFICATION_CLICK",
-      },
-      android: {
-        notification: {
-          icon: icon || "/icons-512.png",
-          imageUrl: icon || "/icons-512.png",
-        },
       },
     };
     await getMessaging().send(message);


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #254 
기존 FCM message payload의 Notification에 담겨있던 title과 body를 data로 이동시킵니다 (android 앱과의 호환성 확보를 위해서입니다).

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음 (알림이 잘 동작하기 때문입니다 >.<)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
