### PR TITLE
#266 deviceToken & notificationOption 조회 및 수정 API 재정의

### DIFF
--- a/src/routes/docs/logininfo.js
+++ b/src/routes/docs/logininfo.js
@@ -1,9 +1,9 @@
 const logininfoDocs = {
-  "/logininfo/detail": {
+  "/logininfo": {
     get: {
       tags: ["logininfo"],
-      summary: "상세한 사용자 정보 반환",
-      description: "로그인되어 있는 사용자의 <b>상세한</b> 정보를 반환",
+      summary: "사용자 정보 반환",
+      description: "로그인되어 있는 사용자의 정보를 반환",
       responses: {
         200: {
           description:
@@ -70,40 +70,6 @@ const logininfoDocs = {
                   },
                   account: {
                     type: "string",
-                  },
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-  },
-  "/logininfo": {
-    get: {
-      tags: ["logininfo"],
-      summary: "사용자 정보 반환",
-      description: "로그인되어 있는 사용자의 정보를 반환",
-      responses: {
-        200: {
-          description:
-            "사용자의 로그인 세션이 유효한 경우, 현재 로그인된 사용자의 정보를 반환, <br/> 세션이 유효하지 않은 경우, 빈 오브젝트를 반환",
-          content: {
-            "application/json": {
-              schema: {
-                type: "object",
-                properties: {
-                  id: {
-                    type: "string",
-                    description: "사용자 id",
-                  },
-                  sid: {
-                    type: "string",
-                    description: "사용자 sid",
-                  },
-                  name: {
-                    type: "string",
-                    description: "사용자 이름",
                   },
                 },
               },

--- a/src/routes/docs/logininfo.js
+++ b/src/routes/docs/logininfo.js
@@ -71,6 +71,15 @@ const logininfoDocs = {
                   account: {
                     type: "string",
                   },
+                  deviceToken: {
+                    type: "string",
+                    description:
+                      "클라이언트의 디바이스 토큰, 세션에 저장되어 있지 않은 경우 undefined",
+                  },
+                  deviceType: {
+                    type: "string",
+                    enum: ["web", "app"],
+                  },
                 },
               },
             },

--- a/src/routes/logininfo.js
+++ b/src/routes/logininfo.js
@@ -4,6 +4,8 @@ const router = express.Router();
 const logininfoHandlers = require("../services/logininfo");
 
 router.route("/").get(logininfoHandlers.logininfoHandler);
-router.route("/detail").get(logininfoHandlers.detailHandler);
+
+// front 작업 이후 미지원 할 API
+router.route("/detail").get(logininfoHandlers.logininfoHandler);
 
 module.exports = router;

--- a/src/routes/notifications.js
+++ b/src/routes/notifications.js
@@ -16,15 +16,10 @@ router.post(
   notificationHandlers.registerDeviceTokenHandler
 );
 
-router.get(
-  "/options",
-  query("deviceToken").isString(),
-  notificationHandlers.optionsHandler
-);
+router.get("/options", notificationHandlers.optionsHandler);
 
 router.post(
   "/editOptions",
-  body("deviceToken").isString(),
   body("options").isObject(),
   body("options.chatting").optional().isBoolean(),
   body("options.keywords").optional().isArray(),

--- a/src/services/logininfo.js
+++ b/src/services/logininfo.js
@@ -2,12 +2,7 @@ const { userModel } = require("../modules/stores/mongo");
 const { getLoginInfo } = require("../modules/auths/login");
 const logger = require("../modules/logger");
 
-const logininfoHandler = (req, res) => {
-  const user = getLoginInfo(req);
-  res.json(user);
-};
-
-const detailHandler = async (req, res) => {
+const logininfoHandler = async (req, res) => {
   try {
     const user = getLoginInfo(req);
     if (!user.id) return res.json({ id: undefined });
@@ -40,5 +35,4 @@ const detailHandler = async (req, res) => {
 
 module.exports = {
   logininfoHandler,
-  detailHandler,
 };

--- a/src/services/logininfo.js
+++ b/src/services/logininfo.js
@@ -1,38 +1,41 @@
 const { userModel } = require("../modules/stores/mongo");
 const { getLoginInfo } = require("../modules/auths/login");
+const logger = require("../modules/logger");
 
 const logininfoHandler = (req, res) => {
   const user = getLoginInfo(req);
   res.json(user);
 };
 
-const detailHandler = (req, res) => {
-  const user = getLoginInfo(req);
-  if (!user.id) return res.json({ id: undefined });
-  userModel.findOne(
-    { id: user.id },
-    "_id name nickname id withdraw ban joinat agreeOnTermsOfService subinfo email profileImageUrl account",
-    (err, result) => {
-      if (err) res.json({ err: true });
-      else if (!result) res.json({ err: true });
-      else {
-        res.json({
-          oid: result._id,
-          id: result.id,
-          name: result.name,
-          nickname: result.nickname,
-          withdraw: result.withdraw,
-          ban: result.ban,
-          joinat: result.joinat,
-          agreeOnTermsOfService: result.agreeOnTermsOfService,
-          subinfo: result.subinfo,
-          email: result.email,
-          profileImgUrl: result.profileImageUrl,
-          account: result.account ? result.account : "",
-        });
-      }
-    }
-  );
+const detailHandler = async (req, res) => {
+  try {
+    const user = getLoginInfo(req);
+    if (!user.id) return res.json({ id: undefined });
+
+    const userDetail = await userModel.findOne(
+      { id: user.id },
+      "_id name nickname id withdraw ban joinat agreeOnTermsOfService subinfo email profileImageUrl account"
+    );
+
+    res.json({
+      oid: userDetail._id,
+      id: userDetail.id,
+      name: userDetail.name,
+      nickname: userDetail.nickname,
+      withdraw: userDetail.withdraw,
+      ban: userDetail.ban,
+      joinat: userDetail.joinat,
+      agreeOnTermsOfService: userDetail.agreeOnTermsOfService,
+      subinfo: userDetail.subinfo,
+      email: userDetail.email,
+      profileImgUrl: userDetail.profileImageUrl,
+      account: userDetail.account ? userDetail.account : "",
+      deviceToken: req.session?.deviceToken,
+    });
+  } catch (error) {
+    logger.error(error);
+    res.json({ err: true });
+  }
 };
 
 module.exports = {

--- a/src/services/logininfo.js
+++ b/src/services/logininfo.js
@@ -26,6 +26,7 @@ const logininfoHandler = async (req, res) => {
       profileImgUrl: userDetail.profileImageUrl,
       account: userDetail.account ? userDetail.account : "",
       deviceToken: req.session?.deviceToken,
+      deviceType: req.session?.isApp ? "app" : "web",
     });
   } catch (error) {
     logger.error(error);

--- a/src/services/notifications.js
+++ b/src/services/notifications.js
@@ -35,13 +35,12 @@ const registerDeviceTokenHandler = async (req, res) => {
 
 const optionsHandler = async (req, res) => {
   try {
-    const { deviceToken } = req.query;
-
-    // 세션에 저장된 deviceToken과 요청에 들어온 deviceToken이 일치하는지 검사합니다.
-    if (req.session?.deviceToken !== deviceToken) {
+    // 세션에 deviceToken이 저장되어 있는지 검사합니다.
+    const { deviceToken } = req.session;
+    if (!deviceToken) {
       return res
         .status(400)
-        .send("Notifications/options : deviceToken is invalid");
+        .send("Notifications/options : deviceToken not found");
     }
 
     // deviceToken에 대응되는 알림 설정을 찾아 반환합니다.
@@ -54,7 +53,7 @@ const optionsHandler = async (req, res) => {
     if (!notificationOptions) {
       return res
         .status(400)
-        .send("Notificaiton/options: deviceToken not found");
+        .send("Notificaiton/options: notificationOption not found");
     }
 
     res.status(200).json(notificationOptions);
@@ -68,13 +67,14 @@ const optionsHandler = async (req, res) => {
 
 const editOptionsHandler = async (req, res) => {
   try {
-    const { deviceToken, options } = req.body;
+    const { options } = req.body;
 
-    // 세션에 저장된 deviceToken과 요청에 들어온 deviceToken이 일치하는지 검사합니다.
-    if (req.session?.deviceToken !== deviceToken) {
+    // 세션에 deviceToken이 저장되어 있는지 검사합니다.
+    const { deviceToken } = req.session;
+    if (!deviceToken) {
       return res
         .status(400)
-        .send("Notifications/editOptions : deviceToken is invalid");
+        .send("Notifications/options : deviceToken not found");
     }
 
     // FIXME : can refactor with using reduce

--- a/test/logininfo.js
+++ b/test/logininfo.js
@@ -5,7 +5,7 @@ const { userModel } = require("../src/modules/stores/mongo");
 // 1-1. 로그인 한 유저가 없을 시 undefined를 return 하는지 확인
 // 1-2. login 정보를 잘 return 하는지 확인
 // 1-3. 세션이 만료됐을 때 undefined를 잘 return 하는지 확인
-describe("[logininfo] 1.detailHandler", () => {
+describe("[logininfo] 1.loginingoHandler", () => {
   it("should return { id: undefined } when no user is logged in", () => {
     const req = { session: {} };
     const res = {

--- a/test/logininfo.js
+++ b/test/logininfo.js
@@ -2,76 +2,10 @@ const expect = require("chai").expect;
 const logininfoHandlers = require("../src/services/logininfo");
 const { userModel } = require("../src/modules/stores/mongo");
 
-// logininfo.js 관련 2개의 handler을 테스트 (동기식이므로 httpMocks 사용하지 않음)
 // 1-1. 로그인 한 유저가 없을 시 undefined를 return 하는지 확인
 // 1-2. login 정보를 잘 return 하는지 확인
 // 1-3. 세션이 만료됐을 때 undefined를 잘 return 하는지 확인
-describe("[logininfo] 1.logininfoHandler", () => {
-  it("should return {id: undefined, sid: undefined, name: undefined } when no user is logged in", () => {
-    const req = { session: {} };
-    const res = {
-      json: (data) => {
-        expect(data).to.deep.equal({
-          id: undefined,
-          sid: undefined,
-          name: undefined,
-        });
-      },
-    };
-    logininfoHandlers.logininfoHandler(req, res);
-  });
-
-  it("should return {id: 'hello-id', sid: 'hello-sid', 'name': 'hello-name'} when user is logged in", () => {
-    const req = {
-      session: {
-        loginInfo: {
-          id: "hello-id",
-          sid: "hello-sid",
-          name: "hello-name",
-          time: Date.now(),
-        },
-      },
-    };
-    const res = {
-      json: (data) => {
-        expect(data).to.deep.equal({
-          id: "hello-id",
-          sid: "hello-sid",
-          name: "hello-name",
-        });
-      },
-    };
-    logininfoHandlers.logininfoHandler(req, res);
-  });
-
-  it("should return {id: undefined, sid: undefined, name: undefined } when the session is expired", () => {
-    const req = {
-      session: {
-        loginInfo: {
-          id: "hello-id",
-          sid: "hello-sid",
-          name: "hello-name",
-          time: new Date(Date.now() - (14 * 24 * 3600 * 1000 + 1)).getTime(), // the session should expire after 1 hour
-        },
-      },
-    };
-    const res = {
-      json: (data) => {
-        expect(data).to.deep.equal({
-          id: undefined,
-          sid: undefined,
-          name: undefined,
-        });
-      },
-    };
-    logininfoHandlers.logininfoHandler(req, res);
-  });
-});
-
-// 2-1. 로그인 한 유저가 없을 시 undefined를 return 하는지 확인
-// 2-2. login detail 정보를 잘 return 하는지 확인
-// 2-3. 세션이 만료됐을 때 undefined를 잘 return 하는지 확인
-describe("[logininfo] 2.detailHandler", () => {
+describe("[logininfo] 1.detailHandler", () => {
   it("should return { id: undefined } when no user is logged in", () => {
     const req = { session: {} };
     const res = {
@@ -81,7 +15,7 @@ describe("[logininfo] 2.detailHandler", () => {
         });
       },
     };
-    logininfoHandlers.detailHandler(req, res);
+    logininfoHandlers.logininfoHandler(req, res);
   });
 
   it("should return correct information as same as user's when user is logged in", async () => {
@@ -117,7 +51,7 @@ describe("[logininfo] 2.detailHandler", () => {
         });
       },
     };
-    logininfoHandlers.detailHandler(req, res);
+    logininfoHandlers.logininfoHandler(req, res);
   });
 
   it("should return {id: undefined} when the session is expired", () => {
@@ -138,6 +72,6 @@ describe("[logininfo] 2.detailHandler", () => {
         });
       },
     };
-    logininfoHandlers.detailHandler(req, res);
+    logininfoHandlers.logininfoHandler(req, res);
   });
 });


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #266 
1. 기존 session에 저장돼있는 deviceToken을 사용자가 /loginInfo/detail을 호출할 때 반환합니다.
2. notificationOption을 조회/수정할 때 사용자가 deviceToken을 보낼 필요 없이 기존 session의 deviceToken을 사용하도록 수정하였습니다.
-> 이를 통해 웹뷰 기반으로 구동되는 택시 앱 환경에서도 deviceToken 없이 마이페이지에서 알림 설정을 수정할 수 있습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

[TODO] Postman 스크린샷 추가

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 프론트 이슈 개설
