### PR TITLE
[Bug] `/rooms/search` api 호출 시 현재 시각 이전의 방이 검색 결과에 포함됨

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "supertest": "^6.2.4"
   },
   "scripts": {
-    "start": "npx nodemon app.js",
-    "test": "npm run sample && npm run mocha",
+    "start": "cross-env TZ='Asia/Seoul' npx nodemon app.js",
+    "test": "npm run sample && cross-env TZ='Asia/Seoul' npm run mocha",
     "mocha": "cross-env TZ='Asia/Seoul' NODE_ENV=test mocha --recursive --reporter spec --exit",
     "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node app.js",
     "lint": "npx eslint --fix .",

--- a/src/services/rooms.js
+++ b/src/services/rooms.js
@@ -311,7 +311,7 @@ const searchHandler = async (req, res) => {
     currentTime.setSeconds(0);
     currentTime.setMilliseconds(0);
 
-    const searchedTime = time ? new Date(time) : currentTime;
+    const searchedTime = time ? new Date(time) : new Date(currentTime);
     if (!withTime) {
       searchedTime.setHours(0);
       searchedTime.setMinutes(0);


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #274 

`/rooms/search` API를 `isHome=true` query만 설정하고 호출하였을 때 현재 시각 이전의 방이 검색 결과에 포함되는 문제를 해결합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
