### PR TITLE
#280 로그인을 요구하지 않는 방 정보 반환 API 개발

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,6 @@ module.exports = {
   },
   rules: {
     "no-unused-vars": 1,
+    "mocha/no-mocha-arrows": 0,
   },
 };

--- a/src/modules/populates/rooms.js
+++ b/src/modules/populates/rooms.js
@@ -13,7 +13,7 @@ const roomPopulateOption = [
 ];
 
 /**
- * Room Object가 주어졌을 때 room의 part array의 각 요소를 API 명세에서와 같이 {userId: String, ... , settlementStatus: String}으로 가공합니다.
+ * Room Object가 주어졌을 때 room의 part array의 각 요소를 API 명세에서와 같이 {userId: String, ... , isSettlement: String}으로 가공합니다.
  * 또한, 방이 현재 출발했는지 유무인 isDeparted 속성을 추가합니다.
  * @param {Object} roomObject - 정산 정보를 가공할 room Object로, Mongoose Document가 아닌 순수 Javascript Object여야 합니다.
  * @param {Object} options - 추가 파라미터로, 기본값은 {}입니다.

--- a/src/routes/rooms.js
+++ b/src/routes/rooms.js
@@ -22,6 +22,14 @@ router.get(
   roomHandlers.searchHandler
 );
 
+// 특정 id 방의 정산 정보를 제외한 세부사항을 반환한다.
+router.get(
+  "/publicInfo",
+  query("id").isMongoId(),
+  validator,
+  roomHandlers.publicInfoHandler
+);
+
 // 이후 API 접근 시 로그인 필요
 router.use(require("../middlewares/auth"));
 

--- a/src/services/rooms.js
+++ b/src/services/rooms.js
@@ -91,6 +91,28 @@ const createHandler = async (req, res) => {
   }
 };
 
+const publicInfoHandler = async (req, res) => {
+  try {
+    const roomObject = await roomModel
+      .findOne({ _id: req.query.id })
+      .lean()
+      .populate(roomPopulateOption);
+    if (roomObject) {
+      // 방의 정산 정보는 개인정보로 방에 참여하기 전까지는 반환하지 않습니다.
+      res.send(formatSettlement(roomObject, { includeSettlement: false }));
+    } else {
+      res.status(404).json({
+        error: "Rooms/info : id does not exist",
+      });
+    }
+  } catch (err) {
+    logger.error(err);
+    res.status(500).json({
+      error: "Rooms/info : internal server error",
+    });
+  }
+};
+
 const infoHandler = async (req, res) => {
   try {
     const user = await userModel.findOne({ id: req.userId });
@@ -620,6 +642,7 @@ const settlementHandler = async (req, res) => {
 // };
 
 module.exports = {
+  publicInfoHandler,
   infoHandler,
   createHandler,
   joinHandler,

--- a/test/rooms.js
+++ b/test/rooms.js
@@ -16,7 +16,7 @@ const removeTestData = async () => {
   await testRemover(testData);
 };
 
-// rooms.js 관련 8개의 handler을 테스트
+// rooms.js 관련 9개의 handler을 테스트
 // 1. test1이 1분 뒤에 출발하는 test-room 방을 생성, 제대로 생성 되었는지 확인
 describe("[rooms] 1.createHandler", () => {
   it("should create room which departs after 1 minute", async () => {
@@ -62,8 +62,24 @@ describe("[rooms] 2.infoHandler", () => {
   });
 });
 
-// 3. test2가 test-room에 join, 방에 잘 join 했는지 확인
-describe("[rooms] 3.joinHandler", () => {
+// 3. 로그인되지 않은 유저가 방의 정보를 제대로 가져오는지 확인
+describe("[rooms] 3.publicInfoHandler", () => {
+  it("should return information of room", async () => {
+    const testRoom = await roomModel.findOne({ name: "test-room" });
+    let req = httpMocks.createRequest({
+      query: { id: testRoom._id },
+    });
+    let res = httpMocks.createResponse();
+    await roomsHandlers.publicInfoHandler(req, res);
+
+    const resData = res._getData();
+    expect(resData).to.has.property("name", "test-room");
+    expect(resData).to.has.property("isOver", undefined);
+  });
+});
+
+// 4. test2가 test-room에 join, 방에 잘 join 했는지 확인
+describe("[rooms] 4.joinHandler", () => {
   it("should return information of room and join", async () => {
     const testUser2 = await userGenerator("test2", testData);
     const testRoom = await roomModel.findOne({ name: "test-room" });
@@ -83,8 +99,8 @@ describe("[rooms] 3.joinHandler", () => {
   });
 });
 
-// 4. 방의 정보를 통해 검색, 검색 정보가 예상과 일치하는지 확인
-describe("[rooms] 4.searchHandler", () => {
+// 5. 방의 정보를 통해 검색, 검색 정보가 예상과 일치하는지 확인
+describe("[rooms] 5.searchHandler", () => {
   it("should return information of searching room", async () => {
     const testFrom = await locationModel.findOne({ koName: "대전역" });
     const testTo = await locationModel.findOne({ koName: "택시승강장" });
@@ -107,9 +123,9 @@ describe("[rooms] 4.searchHandler", () => {
   });
 });
 
-// 5. 방에 속한 유저를 통해 검색
+// 6. 방에 속한 유저를 통해 검색
 // ongoing은 test-room이 검색되고, done은 아무것도 검색되지 않아야함
-describe("[rooms] 5.searchByUserHandler", () => {
+describe("[rooms] 6.searchByUserHandler", () => {
   it("should return information of searching room", async () => {
     const testUser1 = await userModel.findOne({ id: "test1" });
     let req = httpMocks.createRequest({
@@ -124,8 +140,8 @@ describe("[rooms] 5.searchByUserHandler", () => {
   });
 });
 
-// 6.1분이 지난 후, 정산 정보를 불러옴. 예상과 같은 정보를 불러오는지 확인
-describe("[rooms] 6.commitPaymentHandler", () => {
+// 7. 1분이 지난 후, 정산 정보를 불러옴. 예상과 같은 정보를 불러오는지 확인
+describe("[rooms] 7.commitPaymentHandler", () => {
   it("should return information of room and commit payment", async () => {
     const testUser1 = await userModel.findOne({ id: "test1" });
     const testRoom = await roomModel.findOne({ name: "test-room" });
@@ -145,8 +161,8 @@ describe("[rooms] 6.commitPaymentHandler", () => {
   });
 });
 
-// 7. 도착 정보를 불러옴. 예상과 같은 정보를 불러오는지 확인
-describe("[rooms] 7.settlementHandler", () => {
+// 8. 도착 정보를 불러옴. 예상과 같은 정보를 불러오는지 확인
+describe("[rooms] 8.settlementHandler", () => {
   it("should return information of room and set settlement", async () => {
     const testUser2 = await userModel.findOne({ id: "test2" });
     const testRoom = await roomModel.findOne({ name: "test-room" });
@@ -165,8 +181,8 @@ describe("[rooms] 7.settlementHandler", () => {
   });
 });
 
-// 8. test2 방에서 퇴장, 제대로 방에서 나갔는지 확인하고 생성해준 data 모두 삭제
-describe("[rooms] 8.abortHandler", () => {
+// 9. test2 방에서 퇴장, 제대로 방에서 나갔는지 확인하고 생성해준 data 모두 삭제
+describe("[rooms] 9.abortHandler", () => {
   it("should return information of room and abort user", async () => {
     const testUser2 = await userModel.findOne({ id: "test2" });
     const testRoom = await roomModel.findOne({ name: "test-room" });


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #280 
로그인 없이도 (정산 정보를 제외한) 방 정보를 볼 수 있는 API를 작성합니다.
로그인 없이 접속할 수 있는 택시 공유 링크 클릭 시 방의 정보를 볼 수 있게 하기 위해서입니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="600" alt="스크린샷 2023-04-26 오전 1 31 33" src="https://user-images.githubusercontent.com/46402016/234342946-7664c1a2-c84a-40fd-84f4-f1ca5f577434.png">
(Postman에서 API 요청을 보낸 결과)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- https://github.com/sparcs-kaist/taxi-front/issues/544 해결
