### PR TITLE
#263-채팅-socket-구조-개편

### DIFF
--- a/src/modules/auths/login.js
+++ b/src/modules/auths/login.js
@@ -26,10 +26,8 @@ const login = (req, sid, id, oid, name) => {
 
 const logout = (req) => {
   // 로그아웃 전 socket.io 소켓들 연결부터 끊기
-  if (req.session.socketId) {
-    req.app.get("io").in(req.session.socketId).disconnectSockets(true);
-  }
   req.session.destroy((err) => {
+    req.app.get("io").in(req.session.id).disconnectSockets(true);
     if (err) logger.error(err);
   });
 };

--- a/src/modules/auths/login.js
+++ b/src/modules/auths/login.js
@@ -26,8 +26,10 @@ const login = (req, sid, id, oid, name) => {
 
 const logout = (req) => {
   // 로그아웃 전 socket.io 소켓들 연결부터 끊기
+  const io = req.app.get("io");
+  if (io) io.in(req.session.id).disconnectSockets(true);
+
   req.session.destroy((err) => {
-    req.app.get("io").in(req.session.id).disconnectSockets(true);
     if (err) logger.error(err);
   });
 };

--- a/src/modules/socket.js
+++ b/src/modules/socket.js
@@ -223,7 +223,6 @@ const startSocketServer = (server) => {
 
         socket.join(`session-${req.session.id}`);
         socket.join(`user-${userOid}`);
-        req.session.save();
       });
 
       socket.on("disconnect", () => {});

--- a/src/modules/socket.js
+++ b/src/modules/socket.js
@@ -154,7 +154,7 @@ const emitChatEvent = async (io, chat) => {
     const chatsForRoom = await transformChatsForRoom([chatDocument]);
     await Promise.all(
       userIds.map(async (userId) =>
-        io.to(`user-${userId}`).emit("chat_push_back", {
+        io.in(`user-${userId}`).emit("chat_push_back", {
           chats: chatsForRoom,
           roomId,
         })
@@ -221,22 +221,11 @@ const startSocketServer = (server) => {
         const { oid: userOid } = getLoginInfo(req);
         if (!userOid) return;
 
+        socket.join(`session-${req.session.id}`);
         socket.join(`user-${userOid}`);
-        req.session.socketId = socket.id;
         req.session.save();
       });
 
-      socket.on("health", () => {
-        req.session.reload((err) => {
-          if (req.session.socketId === socket.id) {
-            socket.emit("health", true);
-          } else {
-            req.session.socketId = socket.id;
-            req.session.save();
-            socket.emit("health", false);
-          }
-        });
-      });
       socket.on("disconnect", () => {});
     } catch (err) {
       logger.error(err);

--- a/src/services/chats.js
+++ b/src/services/chats.js
@@ -10,11 +10,11 @@ const loadRecentChatHandler = async (req, res) => {
     const io = req.app.get("io");
     const { userId } = req;
     const { roomId } = req.body;
-    const { socketId } = req.session;
+    const { id: sessionId } = req.session;
     if (!userId) {
       return res.status(500).send("Chat/ : internal server error");
     }
-    if (!socketId || !io) {
+    if (!io) {
       return res.status(403).send("Chat/ : socket did not connected");
     }
 
@@ -34,7 +34,7 @@ const loadRecentChatHandler = async (req, res) => {
 
     if (chats) {
       chats.reverse();
-      io.to(socketId).emit("chat_init", {
+      io.in(`session-${sessionId}`).emit("chat_init", {
         chats: await transformChatsForRoom(chats),
       });
       res.json({ result: true });
@@ -51,11 +51,11 @@ const loadBeforeChatHandler = async (req, res) => {
     const io = req.app.get("io");
     const { userId } = req;
     const { roomId, lastMsgDate } = req.body;
-    const { socketId } = req.session;
+    const { id: sessionId } = req.session;
     if (!userId) {
       return res.status(500).send("Chat/load/before : internal server error");
     }
-    if (!socketId || !io) {
+    if (!io) {
       return res
         .status(403)
         .send("Chat/load/before : socket did not connected");
@@ -77,7 +77,7 @@ const loadBeforeChatHandler = async (req, res) => {
 
     if (chats) {
       chats.reverse();
-      io.to(socketId).emit("chat_push_front", {
+      io.in(`session-${sessionId}`).emit("chat_push_front", {
         chats: await transformChatsForRoom(chats),
       });
       res.json({ result: true });
@@ -94,11 +94,11 @@ const loadAfterChatHandler = async (req, res) => {
     const io = req.app.get("io");
     const { userId } = req;
     const { roomId, lastMsgDate } = req.body;
-    const { socketId } = req.session;
+    const { id: sessionId } = req.session;
     if (!userId) {
       return res.status(500).send("Chat/load/after : internal server error");
     }
-    if (!socketId || !io) {
+    if (!io) {
       return res.status(403).send("Chat/load/after : socket did not connected");
     }
 
@@ -117,7 +117,7 @@ const loadAfterChatHandler = async (req, res) => {
       .populate(chatPopulateOption);
 
     if (chats) {
-      io.to(socketId).emit("chat_push_back", {
+      io.in(`session-${sessionId}`).emit("chat_push_back", {
         chats: await transformChatsForRoom(chats),
       });
       res.json({ result: true });
@@ -134,13 +134,12 @@ const sendChatHandler = async (req, res) => {
     const io = req.app.get("io");
     const { userId } = req;
     const { roomId, type, content } = req.body;
-    const { socketId } = req.session;
     const user = await userModel.findOne({ id: userId });
 
     if (!userId || !user) {
       return res.status(500).send("Chat/send : internal server error");
     }
-    if (!socketId || !io) {
+    if (!io) {
       return res.status(403).send("Chat/send : socket did not connected");
     }
 

--- a/src/services/rooms.js
+++ b/src/services/rooms.js
@@ -229,11 +229,6 @@ const abortHandler = async (req, res) => {
       return;
     }
 
-    // 사용자가 채팅방에 들어와있는 경우, 소켓 연결을 먼저 끊습니다.
-    if (req.session.socketId) {
-      req.app.get("io").in(req.session.socketId).disconnectSockets(true);
-    }
-
     // 해당 방의 참여자 목록에서 사용자를 제거합니다.
     // 사용자가 해당 룸의 구성원이 아닌 경우, 403 오류를 반환합니다.
     const roomPartIndex = room.part


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->
It closes #263

기존의 socketId 기반 socket 통신을 sessionId를 통해 구독으로 바꾸어 세션의 변경 없이 소켓 통신이 가능하도록 구조를 개편합니다.
taxi-front SocketToastProvider에서 health 관련 code 변경 시 제대로 작동합니다.