### PR TITLE
[Bug] 계좌번호를 보낼 때 알림이 전송되지 않음

### DIFF
--- a/src/modules/socket.js
+++ b/src/modules/socket.js
@@ -55,8 +55,10 @@ const transformChatsForRoom = async (chats) => {
   return chatsToSend;
 };
 
-// FCM 알림으로 보내는 content는 채팅 type에 따라 달라집니다.
-// type이 text인 경우 `${nickname}: ${content}`를, 아닌 경우 `${nickname}`를 보냅니다.
+/**
+ * FCM 알림으로 보내는 content는 채팅 type에 따라 달라집니다.
+ * 예를 들어, type이 "text"인 경우 `${nickname}: ${content}`를 보냅니다.
+ */
 const getMessageBody = (type, nickname, content) => {
   // TODO: 채팅 메시지 유형에 따라 Body를 다르게 표시합니다.
   if (type === "text") {
@@ -65,7 +67,7 @@ const getMessageBody = (type, nickname, content) => {
   } else if (type === "s3img") {
     // 채팅 유형이 이미지인 경우 본문은 "${nickname} 님이 이미지를 전송하였습니다"가 됩니다.
     // TODO: 사용자 언어를 가져올 수 있으면 개선할 수 있다고 생각합니다.
-    const suffix = " 님이 이미지를 전송하였습니다.";
+    const suffix = " 님이 이미지를 전송하였습니다";
     return `${nickname} ${suffix}`;
   } else if (type === "in" || type === "out") {
     // 채팅 메시지 type이 "in"이거나 "out"인 경우 본문은 "${nickname} 님이 입장하였습니다" 또는 "${nickname} 님이 퇴장하였습니다"가 됩니다.
@@ -81,6 +83,12 @@ const getMessageBody = (type, nickname, content) => {
         ? " 님이 결제를 완료하였습니다"
         : " 님이 정산을 완료하였습니다";
     return `${nickname} ${suffix}`;
+  } else if (type === "account") {
+    const suffix = " 님이 계좌번호를 전송하였습니다";
+    return `${nickname} ${suffix}`;
+  } else {
+    // 정의되지 않은 type의 경우에는 nickname만 반환합니다.
+    return nickname;
   }
 };
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #307 
계좌번호를 보낼 때 서버에서 각 기기로 알림을 전송하는 `emitChatEvent` 함수가 동작하지 않는 문제를 해결합니다.
채팅 type에 따라 알림의 본문(content)을 생성하는 `getMessageBody` 함수에서 정의되지 않은 type에 대해서는 `undefined`를 반환하기 때문에 문제가 발생했습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="354" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/46402016/12f09acf-0290-4bad-ba52-97703e4e22b6">


# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
