### PR TITLE
#320 `/locations` API에 위도, 경도 추가

### DIFF
--- a/src/modules/stores/mongo.js
+++ b/src/modules/stores/mongo.js
@@ -114,8 +114,8 @@ const locationSchema = Schema({
   koName: { type: String, required: true },
   priority: { type: Number, default: 0 },
   isValid: { type: Boolean, default: true },
-  // latitude: { type: Number, required: true },
-  // longitude: { type: Number, required: true }
+  latitude: { type: Number }, // 이후 required: true 로 수정 필요
+  longitude: { type: Number }, // 이후 required: true 로 수정 필요
 });
 const chatSchema = Schema({
   roomId: { type: Schema.Types.ObjectId, ref: "Room", required: true },


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #320 

권장 위도 경도 값

|위치|latitude|longitude|
|------|---|---|
|카이스트 본원|36.3723596|127.358697|
|대전역|36.3319731|127.4323382|
|갤러리아 타임월드|36.3517852|127.3787589|
|궁동 로데오거리|36.3606032|127.3500644|
|대전복합터미널|help?|help?|
|대전청사 고속버스터미널|36.3614807|127.3902714|
|대전청사 시외버스터미널|36.361552|127.3795484|
|만년중학교|help?|help?|
|서대전역|36.3227877|127.404696|
|신세계백화점|36.3744234|127.3820715|
|월평역|36.358475|127.363461|
|유성 고속버스터미널|36.3582923|127.3363614|
|유성 시외버스터미널|36.355613|127.334745|

# Further Works
DB 마이그레이션 이후 `latitude`, `longitude` 필드는 optional 에서 required 로 수정합니다.
