### PR TITLE
#324 [Bug] joinus 함수에서 req 인자가 누락되어 회원가입 불가, #325 [Bug] SPARCS SSO callback 핸들러에 임의로 접근한 경우 TypeError 발생

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -39,7 +39,7 @@ const transUserData = (userData) => {
   return info;
 };
 
-const joinus = async (userData) => {
+const joinus = async (req, userData) => {
   const newUser = new userModel({
     id: userData.id,
     name: userData.name,
@@ -69,7 +69,7 @@ const tryLogin = async (req, res, userData, redirectOrigin, redirectPath) => {
       "_id name id withdraw ban"
     );
     if (!user) {
-      await joinus(userData);
+      await joinus(req, userData);
       return tryLogin(req, res, userData, redirectOrigin, redirectPath);
     }
     if (user.name != userData.name) {
@@ -95,7 +95,7 @@ const tryLogin = async (req, res, userData, redirectOrigin, redirectPath) => {
   } catch (err) {
     logger.error(err);
     const redirectUrl = new URL("/login/fail", redirectOrigin).href;
-    res.redirect(ssoLogoutUrl);
+    res.redirect(redirectUrl);
   }
 };
 

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -114,7 +114,10 @@ const sparcsssoHandler = (req, res) => {
 };
 
 const sparcsssoCallbackHandler = (req, res) => {
-  const { state, redirectOrigin, redirectPath } = req.session?.loginAfterState;
+  const loginAfterState = req.session?.loginAfterState;
+  if (!loginAfterState)
+    return res.status(400).send("SparcsssoCallbackHandler : invalid request");
+  const { state, redirectOrigin, redirectPath } = loginAfterState;
   const stateForCmp = req.body.state || req.query.state;
 
   req.session.loginAfterState = undefined;

--- a/src/services/auth.replace.js
+++ b/src/services/auth.replace.js
@@ -30,7 +30,10 @@ const createUserData = (id) => {
 
 const loginReplaceHandler = (req, res) => {
   const { id } = req.body;
-  const { redirectOrigin, redirectPath } = req.session?.loginAfterState;
+  const loginAfterState = req.session?.loginAfterState;
+  if (!loginAfterState)
+    return res.status(400).send("SparcsssoCallbackHandler : invalid request");
+  const { redirectOrigin, redirectPath } = loginAfterState;
   tryLogin(req, res, createUserData(id), redirectOrigin, redirectPath);
 };
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #324, fixes #325 
1. 사용자가 서비스에 처음 로그인할 때 joinus 함수(sparcs sso로부터 받은 userData를 데이터베이스의 user collection에 저장함)에서 인자로 받지 않은 req의 timestamp 속성을 참조하는 것을 수정하였습니다.
2. SPARCS SSO(와 replace login)의 callback 핸들러에서 session의 loginAfterState 값에 대한 검증을 추가합니다. 

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
