### PR TITLE
#350 `/events/2023fall/items/list`에서 itemType 반환

### DIFF
--- a/loadenv.js
+++ b/loadenv.js
@@ -38,5 +38,5 @@ module.exports = {
   slackWebhookUrl: {
     report: process.env.SLACK_REPORT_WEBHOOK_URL || "", // optional
   },
-  eventMode: "2023fall",
+  eventMode: undefined,
 };

--- a/loadenv.js
+++ b/loadenv.js
@@ -38,5 +38,5 @@ module.exports = {
   slackWebhookUrl: {
     report: process.env.SLACK_REPORT_WEBHOOK_URL || "", // optional
   },
-  eventMode: undefined,
+  eventMode: "2023fall",
 };

--- a/src/lottery/routes/docs/items.js
+++ b/src/lottery/routes/docs/items.js
@@ -58,6 +58,12 @@ itemsDocs[`${apiPrefix}/list`] = {
                         description: "남은 상품 재고. 0 이상입니다.",
                         example: 10,
                       },
+                      itemType: {
+                        type: "number",
+                        description:
+                          "아이템 유형. 0: 티켓아님, 1:티켓 타입1, 2: 티켓 타입 2, 3: 랜덤박스",
+                        example: 0,
+                      },
                     },
                   },
                 },

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -5,7 +5,7 @@ const listHandler = async (_, res) => {
   try {
     const items = await itemModel.find(
       {},
-      "name imageUrl price description isDisabled stock"
+      "name imageUrl price description isDisabled stock itemType"
     );
     res.json({ items });
   } catch (err) {


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #350
클라이언트에서 itemType에 따라 응모권과 응모권이 아닌 것을 구분해 렌더링하기 위해 itemType을 추가 반환합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
