### PR TITLE
#345 [Bug] logger에서 배열을 제대로 출력하지 않음

### DIFF
--- a/src/modules/logger.js
+++ b/src/modules/logger.js
@@ -1,72 +1,95 @@
-const { createLogger, format, transports } = require("winston");
-const dailyRotateFileTransport = require("winston-daily-rotate-file");
 const path = require("path");
+const { createLogger, format, transports } = require("winston");
+const DailyRotateFileTransport = require("winston-daily-rotate-file");
 
 const { nodeEnv } = require("../../loadenv");
 
-// 로깅에 사용하기 위한 포맷을 추가로 정의합니다.
-const customFormat = {
-  time: "YYYY-MM-DD HH:mm:ss", // 로깅 시각
-  line: format.printf(({ level, message, timestamp, stack }) => {
-    return `${timestamp} [${level}]: ${message} ${
-      level === "error" ? stack : ""
-    }`;
-  }), // 메시지 포맷
-  fileDate: "YYYY-MM-DD-HH", // 파일명에 포함되는 시각
-};
+// logger에서 사용할 포맷들을 정의합니다.
+const baseFormat = format.combine(
+  format.timestamp({ format: "YYYY-MM-DD HH:mm:ss(UTCZ)" }),
+  format.errors({ stack: true }),
+  format.splat(),
+  format.json()
+);
+const finalFormat = format.printf(
+  ({ level, message, timestamp, stack }) =>
+    `${timestamp} [${level}]: ${message} ${
+      level === "error" && stack !== undefined ? stack : ""
+    }`
+);
+
+// 파일 출력 시 사용될 포맷. 색 관련 특수문자가 파일에 쓰여지는 것을 방지하기 위해 색상이 표시되지 않습니다.
+const uncolorizedFormat = format.combine(
+  baseFormat,
+  format.uncolorize(),
+  finalFormat
+);
+
+// 콘솔 출력 시 사용될 포맷. 색상이 표시됩니다.
+const colorizedFormat = format.combine(
+  baseFormat,
+  format.colorize({ all: true }),
+  finalFormat
+);
+
+// 로그 파일명에 포함되는 시각
+const datePattern = "YYYY-MM-DD-HH";
+// 로그 파일당 최대 크기(=5MB).
+const maxSize = 5 * 1024 * 1024;
+
+// 콘솔에 출력하기 위한 winston transport
+const consoleTransport = new transports.Console();
 
 /**
- * console.log 대신 사용되는 winston Logger 객체입니다.
+ * console.log()와 console.error() 대신 사용되는 winston Logger 객체입니다.
  *
- * 전체 로그는 *.combined.log 파일에, 예외 처리로 핸들링 된 오류 로그는 *.error.log 파일에, 예외 처리가 되지 않은 오류는 *.unhandled.log에 저장됩니다.
- * @property {function} info() - 일반적인 정보 기록을 위한 로깅(API 접근 기록 등)을 위해 사용합니다.
- * @property {function} error() - 오류 메시지를 로깅하기 위해 사용합니다.
+ * - "production" 환경: 모든 로그는 파일 시스템에 저장되고, 콘솔로도 출력됩니다.
+ * - "development" & "test" 환경: 모든 로그는 콘솔에 출력됩니다.
+ *
+ * @method info(message: string, callback: winston.LogCallback) - 일반적인 정보(API 접근 등) 기록을 위해 사용합니다.
+ * @method error(message: string, callback: winston.LogCallback)  - 오류 메시지를 기록하기 위해 사용합니다.
  */
-const logger = createLogger({
-  format: format.combine(
-    format.timestamp({ format: customFormat.time }),
-    format.errors({ stack: true }),
-    format.splat(),
-    format.json(),
-    customFormat.line
-  ),
-  defaultMeta: { service: "sparcs-taxi" },
-  transports: [
-    new dailyRotateFileTransport({
-      filename: path.resolve("logs/%DATE%-combined.log"),
-      datePattern: customFormat.fileDate,
-      maxsize: 5242880, // 5MB
-      level: "info",
-    }),
-    new dailyRotateFileTransport({
-      filename: path.resolve("logs/%DATE%-error.log"),
-      datePattern: customFormat.fileDate,
-      maxsize: 5242880, // 5MB
-      level: "error",
-    }),
-  ],
-  exceptionHandlers: [
-    new dailyRotateFileTransport({
-      filename: path.resolve("logs/%DATE%-unhandled.log"),
-      datePattern: customFormat.fileDate,
-      maxsize: 5242880, // 5MB
-    }),
-  ],
-});
-
-// If the environment is not production, the log is also recorded on console
-if (nodeEnv !== "production") {
-  logger.add(
-    new transports.Console({
-      format: format.combine(
-        format.timestamp({ format: customFormat.time }),
-        format.errors({ stack: true }),
-        format.splat(),
-        format.colorize(),
-        customFormat.line
-      ),
-    })
-  );
-}
+const logger =
+  nodeEnv === "production"
+    ? // "production" 환경에서 사용되는 Logger 객체
+      createLogger({
+        level: "info",
+        format: uncolorizedFormat,
+        defaultMeta: { service: "sparcs-taxi" },
+        transports: [
+          // 전체 로그("info", "warn", "error")를 파일로 출력합니다.
+          new DailyRotateFileTransport({
+            level: "info",
+            filename: path.resolve("logs/%DATE%-combined.log"),
+            datePattern,
+            maxSize,
+          }),
+          // 예외 처리로 핸들링 된 오류 로그("error")를 파일과 콘솔에 출력합니다.
+          new DailyRotateFileTransport({
+            level: "error",
+            filename: path.resolve("logs/%DATE%-error.log"),
+            datePattern,
+            maxSize,
+          }),
+          consoleTransport,
+        ],
+        exceptionHandlers: [
+          // 예외 처리가 되지 않은 오류 로그("error")를 파일과 콘솔에 출력합니다.
+          new DailyRotateFileTransport({
+            filename: path.resolve("logs/%DATE%-unhandled.log"),
+            datePattern,
+            maxSize,
+          }),
+          consoleTransport,
+        ],
+      })
+    : // "development", "test" 환경에서 사용되는 Logger 객체
+      createLogger({
+        level: "info",
+        format: colorizedFormat,
+        defaultMeta: { service: "sparcs-kaist" },
+        transports: [consoleTransport],
+        exceptionHandlers: [consoleTransport],
+      });
 
 module.exports = logger;


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #345 
택시에서 사용하는 winston 로거는 배열이 아닌 단일 객체를 입력받는 것을 기대하도록 구현되어 있기 때문에, 배열을 출력할 때 대괄호가 생략되는 오류가 발생합니다.
colorize 포맷을 사용할 때 {all: true} 옵션을 전달하여 배열을 출력하기 전 string으로 변환하도록 하였습니다.

이 외에도, 로컬 개발 시 unhandled exception이 파일로만 출력되던 것을 콘솔로 출력되게 바꾸었고, 로컬 개발 환경에서 파일로 로그가 출력되지 않게 변경하였습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="524" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/46402016/cf47c5d6-5d83-44cb-8a49-4e1c395a024f">

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Docker에서 로그 크기 제한하기 (https://docs.docker.com/config/containers/logging/local/#options)
