### PR TITLE
#358 /events/2023fall/global-state API에서 이벤트 목록을 반환하도록 개선

### DIFF
--- a/src/lottery/modules/admin.js
+++ b/src/lottery/modules/admin.js
@@ -21,7 +21,8 @@ const creditTransfer = async (userId, amount, eventId, comment) => {
 };
 
 /** itemId가 없는 경우 null이 아닌 undefined를 넣어야 합니다. */
-const creditWithdraw = async (userId, amount, itemId, comment) => {
+/** itemType이 없는 경우 null이 아닌 undefined를 넣어야 합니다. */
+const creditWithdraw = async (userId, amount, itemId, itemType, comment) => {
   const user = await useUserCreditAmount(userId);
   await user.update(-amount);
 
@@ -30,6 +31,7 @@ const creditWithdraw = async (userId, amount, itemId, comment) => {
     amount,
     userId,
     item: itemId,
+    itemType,
     comment,
   });
   await transaction.save();

--- a/src/lottery/modules/admin.js
+++ b/src/lottery/modules/admin.js
@@ -6,7 +6,7 @@ const { eventEnv } = require("../../../loadenv");
 /** eventId가 없는 경우 null이 아닌 undefined를 넣어야 합니다. */
 const creditTransfer = async (userId, amount, eventId, comment) => {
   const user = await useUserCreditAmount(userId);
-  await user.creditUpdate(amount);
+  await user.update(amount);
 
   const transaction = new transactionModel({
     type: "get",
@@ -23,7 +23,7 @@ const creditTransfer = async (userId, amount, eventId, comment) => {
 /** itemId가 없는 경우 null이 아닌 undefined를 넣어야 합니다. */
 const creditWithdraw = async (userId, amount, itemId, comment) => {
   const user = await useUserCreditAmount(userId);
-  await user.creditUpdate(-amount);
+  await user.update(-amount);
 
   const transaction = new transactionModel({
     type: "use",

--- a/src/lottery/modules/credit.js
+++ b/src/lottery/modules/credit.js
@@ -1,12 +1,12 @@
 const { eventStatusModel } = require("../modules/stores/mongo");
 
 const useUserCreditAmount = async (userId) => {
-  const eventStatus = await eventStatusModel.findOne({ userId });
+  const eventStatus = await eventStatusModel.findOne({ userId }).lean();
   if (!eventStatus) return null;
 
   return {
-    creditAmount: eventStatus.creditAmount,
-    creditUpdate: async (delta) => {
+    amount: eventStatus.creditAmount,
+    update: async (delta) => {
       await eventStatusModel.updateOne(
         { _id: eventStatus._id },
         {

--- a/src/lottery/modules/stores/mongo.js
+++ b/src/lottery/modules/stores/mongo.js
@@ -123,6 +123,10 @@ const transactionSchema = Schema({
     type: Schema.Types.ObjectId,
     ref: "Item",
   },
+  itemType: {
+    type: Number,
+    enum: [0, 1, 2, 3],
+  },
   comment: {
     type: String,
     required: true,

--- a/src/lottery/routes/docs/globalState.js
+++ b/src/lottery/routes/docs/globalState.js
@@ -40,6 +40,45 @@ globalStateDocs[`${apiPrefix}/`] = {
                   description: "추첨권 (2)의 개수. 0 이상입니다.",
                   example: 10,
                 },
+                events: {
+                  type: "array",
+                  description: "Event의 배열",
+                  items: {
+                    type: "object",
+                    properties: {
+                      _id: {
+                        type: "string",
+                        description: "Event의 ObjectId",
+                        example: "OBJECT ID",
+                      },
+                      name: {
+                        type: "string",
+                        description: "이벤트의 이름",
+                        example: "최초 로그인 이벤트",
+                      },
+                      rewardAmount: {
+                        type: "number",
+                        description: "달성 보상",
+                        example: 100,
+                      },
+                      maxCount: {
+                        type: "number",
+                        description: "최대 달성 가능 횟수",
+                        example: 1,
+                      },
+                      expireat: {
+                        type: "string",
+                        description: "달성할 수 있는 마지막 시각",
+                        example: "2023-01-01 00:00:00",
+                      },
+                      isDisabled: {
+                        type: "boolean",
+                        description: "달성 불가능 여부",
+                        example: false,
+                      },
+                    },
+                  },
+                },
               },
             },
           },

--- a/src/lottery/services/globalState.js
+++ b/src/lottery/services/globalState.js
@@ -8,7 +8,9 @@ const logger = require("../../modules/logger");
 
 const getUserGlobalStateHandler = async (req, res) => {
   try {
-    let eventStatus = await eventStatusModel.findOne({ userId: req.userOid });
+    let eventStatus = await eventStatusModel
+      .findOne({ userId: req.userOid })
+      .lean();
     if (!eventStatus) {
       // User마다 EventStatus를 가져야 하고, 현재 Taxi에는 회원 탈퇴 시스템이 없으므로, EventStatus가 없으면 새롭게 생성하도록 구현합니다.
       // EventStatus의 생성은 이곳에서만 이루어집니다!!
@@ -21,17 +23,19 @@ const getUserGlobalStateHandler = async (req, res) => {
     let ticket1Amount = 0;
     let ticket2Amount = 0;
 
-    const itemPurchaseTransactions = await transactionModel.find({
-      userId: req.userOid,
-      type: "use",
-      item: {
-        $exists: true,
-        $ne: null,
-      },
-    });
+    const itemPurchaseTransactions = await transactionModel
+      .find({
+        userId: req.userOid,
+        type: "use",
+        item: {
+          $exists: true,
+          $ne: null,
+        },
+      })
+      .lean();
     await Promise.all(
       itemPurchaseTransactions.map(async (purchase) => {
-        const item = await itemModel.findOne({ _id: purchase.item });
+        const item = await itemModel.findOne({ _id: purchase.item }).lean();
 
         if (item.itemType === 1) {
           ticket1Amount++;
@@ -41,7 +45,7 @@ const getUserGlobalStateHandler = async (req, res) => {
       })
     );
 
-    const events = await eventModel.find({}, "-__v");
+    const events = await eventModel.find({}, "-__v").lean();
 
     res.json({
       creditAmount: eventStatus.creditAmount,

--- a/src/lottery/services/globalState.js
+++ b/src/lottery/services/globalState.js
@@ -20,31 +20,24 @@ const getUserGlobalStateHandler = async (req, res) => {
       await eventStatus.save();
     }
 
-    let ticket1Amount = 0;
-    let ticket2Amount = 0;
-
-    const itemPurchaseTransactions = await transactionModel
-      .find({
-        userId: req.userOid,
-        type: "use",
-        item: {
-          $exists: true,
-          $ne: null,
-        },
-      })
-      .lean();
-    await Promise.all(
-      itemPurchaseTransactions.map(async (purchase) => {
-        const item = await itemModel.findOne({ _id: purchase.item }).lean();
-
-        if (item.itemType === 1) {
-          ticket1Amount++;
-        } else if (item.itemType === 2) {
-          ticket2Amount++;
-        }
-      })
-    );
-
+    const ticket1Amount = await transactionModel.count({
+      userId: req.userOid,
+      type: "use",
+      item: {
+        $exists: true,
+        $ne: null,
+      },
+      itemType: 1,
+    });
+    const ticket2Amount = await transactionModel.count({
+      userId: req.userOid,
+      type: "use",
+      item: {
+        $exists: true,
+        $ne: null,
+      },
+      itemType: 2,
+    });
     const events = await eventModel.find({}, "-__v").lean();
 
     res.json({

--- a/src/lottery/services/globalState.js
+++ b/src/lottery/services/globalState.js
@@ -1,5 +1,6 @@
 const {
   eventStatusModel,
+  eventModel,
   transactionModel,
   itemModel,
 } = require("../modules/stores/mongo");
@@ -30,7 +31,7 @@ const getUserGlobalStateHandler = async (req, res) => {
     });
     await Promise.all(
       itemPurchaseTransactions.map(async (purchase) => {
-        const item = await itemModel.findOne({ _id: purchase.itemId });
+        const item = await itemModel.findOne({ _id: purchase.item });
 
         if (item.itemType === 1) {
           ticket1Amount++;
@@ -40,11 +41,14 @@ const getUserGlobalStateHandler = async (req, res) => {
       })
     );
 
+    const events = await eventModel.find({}, "-__v");
+
     res.json({
       creditAmount: eventStatus.creditAmount,
       eventStatus: eventStatus.eventList.map((id) => id.toString()),
       ticket1Amount,
       ticket2Amount,
+      events,
     });
   } catch (err) {
     logger.error(err);

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -58,6 +58,7 @@ const getRandomItem = async (req, depth) => {
       amount: 0,
       userId: req.userOid,
       item: randomItem._id,
+      itemType: randomItem.itemType,
       comment: `랜덤박스에서 ${randomItem.name} 획득 - 0개 차감`,
     });
     await transaction.save();
@@ -134,6 +135,7 @@ const purchaseHandler = async (req, res) => {
       amount: item.price,
       userId: req.userOid,
       item: item._id,
+      itemType: item.itemType,
       comment: `${item.name} 구입 - ${item.price}개 차감`,
     });
     await transaction.save();

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -17,14 +17,15 @@ const getRandomItem = async (req, depth) => {
       return Array(item.randomWeight).fill(item);
     })
     .reduce((a, b) => a.concat(b), []);
+  const dumpRandomItems = randomItems
+    .map((item) => item._id.toString())
+    .join(",");
 
   logger.info(
-    `유저 "${req.userOid}"에 의해 getRandomItem(depth=${depth})가 호출되었습니다.`
+    `[RandomBox] getRandomItem(depth=${depth}) is called by the user(id=${req.userOid}).`
   );
   logger.info(
-    `유저 "${req.userOid}"의 랜덤박스 확률 정보입니다: [${randomItems
-      .map((item) => item._id.toString())
-      .join(",")}]`
+    `[RandomBox] randomItems of the user(id=${req.userOid}) is [${dumpRandomItems}].`
   );
 
   if (randomItems.length === 0) return null;
@@ -64,10 +65,10 @@ const getRandomItem = async (req, depth) => {
     return newRandomItem;
   } catch (err) {
     logger.warn(
-      `유저 "${req.userOid}"의 랜덤박스 추첨이 실패했습니다. 오류 정보: ${err}`
+      `[RandomBox] getRandomItem(depth=${depth}) by the user(id=${req.userOid}) failed due to ${err}.`
     );
 
-    return await getRandomItem(depth + 1);
+    return await getRandomItem(req, depth + 1);
   }
 };
 

--- a/src/lottery/services/transactions.js
+++ b/src/lottery/services/transactions.js
@@ -8,7 +8,7 @@ const getUserTransactionsHandler = async (req, res) => {
   try {
     // userId는 이미 Frontend에서 알고 있고, 중복되는 값이므로 제외합니다.
     const transactions = await transactionModel
-      .find({ userId: req.userOid }, "-userId -__v")
+      .find({ userId: req.userOid }, "-userId -itemType -__v")
       .populate(transactionPopulateOption)
       .lean();
     if (transactions)

--- a/src/lottery/services/transactions.js
+++ b/src/lottery/services/transactions.js
@@ -6,13 +6,15 @@ const {
 
 const getUserTransactionsHandler = async (req, res) => {
   try {
+    // userId는 이미 Frontend에서 알고 있고, 중복되는 값이므로 제외합니다.
     const transactions = await transactionModel
       .find({ userId: req.userOid }, "-userId -__v")
-      .populate(transactionPopulateOption);
+      .populate(transactionPopulateOption)
+      .lean();
     if (transactions)
       res.json({
         transactions,
-      }); // userId는 이미 Frontend에서 알고 있고, 중복되는 값이므로 제외합니다.
+      });
     else
       res.status(500).json({ error: "Transactions/ : internal server error" });
   } catch (err) {


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #358 
It closes #335 
이제 `global-state` Endpoint에서 events 필드에 모든 이벤트의 목록을 담아 함께 전달합니다. 또, lottery 모듈의 db query를 수정하여 성능을 개선하였습니다. lean을 적극적으로 활용하고, TICKET 1, TICKET 2의 개수를 계산하는 알고리즘도 변경하였습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- `global-notice` API 추가