### PR TITLE
#369 채팅 전송 시 FCM 알림(`sendMessageByTokens`) 비동기적으로 보내기

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ Taxi는 KAIST 구성원들의 택시 동승 인원 모집을 위한 서비스입
 - Slack : #taxi-main, #taxi-notice, #taxi-bug-report, #taxi-github-bot, #taxi-notion-bot (Only SPARCS members can access it)
 
 ## Prerequisites
-- Recommended npm version : 8.5.5 (with node v.16.15.0)
-- Recommended mognoDB version : 5.0.8
+- Recommended pnpm version : 8.7.5 (with node v16.20.1)
+- Recommended mongoDB version : 5.0.8
 - [Issue with node version](https://github.com/sparcs-kaist/taxi-front/issues/76)
 
 ## Project Setup
@@ -24,7 +24,7 @@ $ git clone https://github.com/sparcs-kaist/taxi-back
 
 ### Install Requirements
 ```bash
-$ npm install --save
+$ pnpm i
 ```
 
 ### Set Environment Configuration

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,18 @@
+version: "3"
+services:
+  taxi-mongo:
+    container_name: taxi-mongo-dev
+    image: mongo:4.4
+    restart: unless-stopped
+    ports:
+      - ${MONGO_PORT:-27017}:27017
+    volumes:
+      - taxi-mongo-data:/data/db
+  taxi-redis:
+    container_name: taxi-redis-dev
+    image: redis:7.0.4-alpine
+    restart: unless-stopped
+    ports:
+      - ${REDIS_PORT:-6379}:6379
+volumes:
+  taxi-mongo-data:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,18 +1,12 @@
 version: "3"
 services:
-  taxi-mongo:
-    container_name: taxi-mongo-dev
-    image: mongo:4.4
-    restart: unless-stopped
-    ports:
-      - ${MONGO_PORT:-27017}:27017
-    volumes:
-      - taxi-mongo-data:/data/db
   taxi-redis:
     container_name: taxi-redis-dev
     image: redis:7.0.4-alpine
     restart: unless-stopped
     ports:
       - ${REDIS_PORT:-6379}:6379
+    volumes:
+      - taxi-redis-data:/data
 volumes:
-  taxi-mongo-data:
+  taxi-redis-data:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dev": "cross-env TZ='Asia/Seoul' npx nodemon app.js",
     "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node app.js",
     "worker:dev": "cross-env TZ='Asia/Seoul' npx nodemon worker.js",
-    "worker:prod": "cross-env TZ='Asia/Seoul' node worker.js",
+    "worker:prod": "cross-env TZ='Asia/Seoul' NODE_ENV=production node worker.js",
     "start": "concurrently \"npm run dev\" \"npm run worker:dev\"",
     "redis:dev": "docker compose -f docker-compose.dev.yml up -d",
     "redis:dev:down": "docker compose -f docker-compose.dev.yml down",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,8 @@
     "worker:dev": "cross-env TZ='Asia/Seoul' npx nodemon worker.js",
     "worker:prod": "cross-env TZ='Asia/Seoul' node worker.js",
     "start": "concurrently \"npm run dev\" \"npm run worker:dev\"",
+    "redis:dev": "docker compose -f docker-compose.dev.yml up -d",
+    "redis:dev:down": "docker compose -f docker-compose.dev.yml down",
     "test": "npm run sample && cross-env TZ='Asia/Seoul' npm run mocha",
     "mocha": "cross-env TZ='Asia/Seoul' NODE_ENV=test mocha --recursive --reporter spec --exit",
     "lint": "npx eslint --fix .",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ajv-formats": "^2.1.1",
     "aws-sdk": "^2.1386.0",
     "axios": "^0.27.2",
+    "bullmq": "^4.11.0",
     "ci": "^2.2.0",
     "connect-mongo": "^4.6.0",
     "connect-redis": "^6.1.3",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "chai": "*",
+    "concurrently": "^8.2.1",
     "eslint": "^8.22.0",
     "eslint-plugin-mocha": "^10.1.0",
     "mocha": "*",
@@ -49,10 +51,13 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "start": "cross-env TZ='Asia/Seoul' npx nodemon app.js",
+    "dev": "cross-env TZ='Asia/Seoul' npx nodemon app.js",
+    "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node app.js",
+    "worker:dev": "cross-env TZ='Asia/Seoul' npx nodemon worker.js",
+    "worker:prod": "cross-env TZ='Asia/Seoul' node worker.js",
+    "start": "concurrently \"npm run dev\" \"npm run worker:dev\"",
     "test": "npm run sample && cross-env TZ='Asia/Seoul' npm run mocha",
     "mocha": "cross-env TZ='Asia/Seoul' NODE_ENV=test mocha --recursive --reporter spec --exit",
-    "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node app.js",
     "lint": "npx eslint --fix .",
     "sample": "cd sampleGenerator && npm start && cd .."
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   axios:
     specifier: ^0.27.2
     version: 0.27.2
+  bullmq:
+    specifier: ^4.11.0
+    version: 4.11.0
   ci:
     specifier: ^2.2.0
     version: 2.2.0
@@ -112,6 +115,9 @@ devDependencies:
   chai:
     specifier: '*'
     version: 4.3.7
+  concurrently:
+    specifier: ^8.2.1
+    version: 8.2.1
   eslint:
     specifier: ^8.22.0
     version: 8.22.0
@@ -1980,7 +1986,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       regenerator-runtime: 0.13.11
-    dev: false
 
   /@babel/template@7.22.5:
     resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
@@ -2410,6 +2415,10 @@ packages:
       warning: 4.0.3
     dev: false
 
+  /@ioredis/commands@1.2.0:
+    resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
+    dev: false
+
   /@jridgewell/gen-mapping@0.3.3:
     resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
@@ -2457,6 +2466,54 @@ packages:
     requiresBuild: true
     dependencies:
       lodash: 4.17.21
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.2:
+    resolution: {integrity: sha512-9bfjwDxIDWmmOKusUcqdS4Rw+SETlp9Dy39Xui9BEGEk19dDwH0jhipwFzEff/pFg95NKymc6TOTbRKcWeRqyQ==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.2:
+    resolution: {integrity: sha512-lwriRAHm1Yg4iDf23Oxm9n/t5Zpw1lVnxYU3HnJPTi2lJRkKTrps1KVgvL6m7WvmhYVt/FIsssWay+k45QHeuw==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.2:
+    resolution: {integrity: sha512-FU20Bo66/f7He9Fp9sP2zaJ1Q8L9uLPZQDub/WlUip78JlPeMbVL8546HbZfcW9LNciEXc8d+tThSJjSC+tmsg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-arm@3.0.2:
+    resolution: {integrity: sha512-MOI9Dlfrpi2Cuc7i5dXdxPbFIgbDBGgKR5F2yWEa6FVEtSWncfVNKW5AKjImAQ6CZlBK9tympdsZJ2xThBiWWA==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-linux-x64@3.0.2:
+    resolution: {integrity: sha512-gsWNDCklNy7Ajk0vBBf9jEx04RUxuDQfBse918Ww+Qb9HCPoGzS+XJTLe96iN3BVK7grnLiYghP/M4L8VsaHeA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: false
+    optional: true
+
+  /@msgpackr-extract/msgpackr-extract-win32-x64@3.0.2:
+    resolution: {integrity: sha512-O+6Gs8UeDbyFpbSh2CPEz/UOrrdWPTBYNblZK5CxxLisYt4kGX3Sc+czffFonyjiGSq3jWLwJS/CCJc7tBr4sQ==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
     dev: false
     optional: true
 
@@ -4260,6 +4317,22 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
+  /bullmq@4.11.0:
+    resolution: {integrity: sha512-e6/CtKHieEplmoP0NE/oty2xmuXGAoHWlpy//hYexljwM14Ff2Gqr4eLscYIdWm3W0OyxWwjjJUPXaOf5BYYvQ==}
+    dependencies:
+      cron-parser: 4.9.0
+      glob: 8.1.0
+      ioredis: 5.3.2
+      lodash: 4.17.21
+      msgpackr: 1.9.9
+      node-abort-controller: 3.1.1
+      semver: 7.5.4
+      tslib: 2.6.1
+      uuid: 9.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
@@ -4387,8 +4460,6 @@ packages:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
-    dev: false
-    optional: true
 
   /clone-deep@4.0.1:
     resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
@@ -4483,6 +4554,22 @@ packages:
 
   /concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  /concurrently@8.2.1:
+    resolution: {integrity: sha512-nVraf3aXOpIcNud5pB9M82p1tynmZkrSGQ1p6X/VY8cJ+2LMVqAgXsJxYYefACSHbTYlm92O1xuhdGTjwoEvbQ==}
+    engines: {node: ^14.13.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      chalk: 4.1.2
+      date-fns: 2.30.0
+      lodash: 4.17.21
+      rxjs: 7.8.1
+      shell-quote: 1.8.1
+      spawn-command: 0.0.2
+      supports-color: 8.1.1
+      tree-kill: 1.2.2
+      yargs: 17.7.2
+    dev: true
 
   /connect-mongo@4.6.0(express-session@1.17.3)(mongodb@4.16.0):
     resolution: {integrity: sha512-8new4Z7NLP3CGP65Aw6ls3xDBeKVvHRSh39CXuDZTQsvpeeU9oNMzfFgvqmHqZ6gWpxIl663RyoVEmCAGf1yOg==}
@@ -4586,6 +4673,13 @@ packages:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
     dev: false
 
+  /cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+    dependencies:
+      luxon: 3.4.3
+    dev: false
+
   /cross-env@7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -4643,7 +4737,6 @@ packages:
     engines: {node: '>=0.11'}
     dependencies:
       '@babel/runtime': 7.22.6
-    dev: false
 
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -4734,6 +4827,11 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
+
+  /denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+    dev: false
 
   /depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -5489,7 +5587,6 @@ packages:
       minimatch: 5.1.6
       once: 1.4.0
     dev: false
-    optional: true
 
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -5738,6 +5835,23 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  /ioredis@5.3.2:
+    resolution: {integrity: sha512-1DKMMzlIHM02eBBVOFQ1+AolGjs6+xEcM4PDL7NqOS6szq7H9jSaEkIUH6/a5Hl241LzW6JLSiAbNvTQjUupUA==}
+    engines: {node: '>=12.22.0'}
+    dependencies:
+      '@ioredis/commands': 1.2.0
+      cluster-key-slot: 1.1.2
+      debug: 4.3.4
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
 
   /ip@2.0.0:
     resolution: {integrity: sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ==}
@@ -6159,8 +6273,16 @@ packages:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
     dev: false
 
+  /lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+    dev: false
+
   /lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
+    dev: false
+
+  /lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
     dev: false
 
   /lodash.isboolean@3.0.3:
@@ -6204,7 +6326,6 @@ packages:
 
   /lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-    dev: false
 
   /log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
@@ -6273,6 +6394,11 @@ packages:
     dependencies:
       lodash.clonedeep: 4.5.0
       lru-cache: 4.0.2
+    dev: false
+
+  /luxon@3.4.3:
+    resolution: {integrity: sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==}
+    engines: {node: '>=12'}
     dev: false
 
   /magic-string@0.25.9:
@@ -6437,7 +6563,6 @@ packages:
     dependencies:
       brace-expansion: 2.0.1
     dev: false
-    optional: true
 
   /minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -6546,6 +6671,28 @@ packages:
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  /msgpackr-extract@3.0.2:
+    resolution: {integrity: sha512-SdzXp4kD/Qf8agZ9+iTu6eql0m3kWm1A2y1hkpTeVNENutaB0BwHlSvAIaMxwntmRUAUjon2V4L8Z/njd0Ct8A==}
+    hasBin: true
+    requiresBuild: true
+    dependencies:
+      node-gyp-build-optional-packages: 5.0.7
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.2
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.2
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.2
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.2
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.2
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.2
+    dev: false
+    optional: true
+
+  /msgpackr@1.9.9:
+    resolution: {integrity: sha512-sbn6mioS2w0lq1O6PpGtsv6Gy8roWM+o3o4Sqjd6DudrL/nOugY+KyJUimoWzHnf9OkO0T6broHFnYE/R05t9A==}
+    optionalDependencies:
+      msgpackr-extract: 3.0.2
+    dev: false
+
   /nanoid@3.3.3:
     resolution: {integrity: sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -6558,6 +6705,10 @@ packages:
   /negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
+    dev: false
+
+  /node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
     dev: false
 
   /node-cron@3.0.2:
@@ -6585,6 +6736,13 @@ packages:
     resolution: {integrity: sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==}
     engines: {node: '>= 6.13.0'}
     dev: false
+
+  /node-gyp-build-optional-packages@5.0.7:
+    resolution: {integrity: sha512-YlCCc6Wffkx0kHkmam79GKvDQ6x+QZkMjFGrIMxgFNILFvGSbCp2fCBC55pGTT9gVaz8Na5CLmxt/urtzRv36w==}
+    hasBin: true
+    requiresBuild: true
+    dev: false
+    optional: true
 
   /node-mocks-http@1.12.2:
     resolution: {integrity: sha512-xhWwC0dh35R9rf0j3bRZXuISXdHxxtMx0ywZQBwjrg3yl7KpRETzogfeCamUIjltpn0Fxvs/ZhGJul1vPLrdJQ==}
@@ -7388,6 +7546,18 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+    dev: false
+
+  /redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+    dependencies:
+      redis-errors: 1.2.0
+    dev: false
+
   /redis@4.6.7:
     resolution: {integrity: sha512-KrkuNJNpCwRm5vFJh0tteMxW8SaUzkm5fBH7eL5hd/D0fAkzvapxbfGPP/r+4JAXdQuX7nebsBkBqA2RHB7Usw==}
     dependencies:
@@ -7418,7 +7588,6 @@ packages:
 
   /regenerator-runtime@0.13.11:
     resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
-    dev: false
 
   /regenerator-transform@0.15.1:
     resolution: {integrity: sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==}
@@ -7554,6 +7723,12 @@ packages:
     dependencies:
       queue-microtask: 1.2.3
 
+  /rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.6.1
+    dev: true
+
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -7676,6 +7851,10 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  /shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+    dev: true
+
   /side-channel@1.0.4:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
@@ -7787,8 +7966,16 @@ packages:
     dev: false
     optional: true
 
+  /spawn-command@0.0.2:
+    resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
+    dev: true
+
   /stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+    dev: false
+
+  /standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
     dev: false
 
   /statuses@2.0.1:
@@ -8059,6 +8246,11 @@ packages:
       punycode: 2.3.0
     dev: false
 
+  /tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+    dev: true
+
   /triple-beam@1.4.1:
     resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
     engines: {node: '>= 14.0.0'}
@@ -8072,7 +8264,6 @@ packages:
 
   /tslib@2.6.1:
     resolution: {integrity: sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==}
-    dev: false
 
   /type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
@@ -8479,8 +8670,6 @@ packages:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
     requiresBuild: true
-    dev: false
-    optional: true
 
   /yargs-unparser@2.0.0:
     resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
@@ -8517,8 +8706,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: false
-    optional: true
 
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}

--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -178,7 +178,6 @@ const getTokensOfUsers = async (userIds, notificationOptions = {}) => {
 
 /**
  * 주어진 token들에 메시지 알림을 전송합니다.
- * TODO: 알림 전송 실패한 토큰 삭제하기
  * @param {Array<string>} tokens - 메시지 알림을 받을 기기의 deviceToken들로 구성된 Array입니다.
  * @param {string} type - 메시지 유형으로, "text" | "in" | "out" | "s3img" | "payment" | "settlement" 입니다.
  * @param {string} title - 보낼 메시지의 제목입니다.

--- a/src/modules/logger.js
+++ b/src/modules/logger.js
@@ -43,10 +43,12 @@ const consoleTransport = new transports.Console();
 /**
  * console.log()와 console.error() 대신 사용되는 winston Logger 객체입니다.
  *
- * - "production" 환경: 모든 로그는 파일 시스템에 저장되고, 콘솔로도 출력됩니다.
- * - "development" & "test" 환경: 모든 로그는 콘솔에 출력됩니다.
+ * - "production" 환경: 모든 로그는 파일 시스템에 저장되고, 콘솔로도 출력됩니다. "info" 레벨 이상의 로그가 출력됩니다.
+ * - "development" & "test" 환경: 모든 로그는 콘솔에 출력됩니다. "debug" 레벨 이상의 로그가 출력됩니다.
  *
+ * @method debug(message: string, callback: winston.LogCallback) - 디버깅을 위한 기록에 사용됩니다. **주의: "production" 환경에서는 debug 로그가 기록되지 않습니다.**
  * @method info(message: string, callback: winston.LogCallback) - 일반적인 정보(API 접근 등) 기록을 위해 사용합니다.
+ * @method warn(message: string, callback: winston.LogCallback) - 예상하지 않은 일이 발생했지만, 애플리케이션에 오류가 발생하지는 않았을 때 경고를 위해 사용합니다.
  * @method error(message: string, callback: winston.LogCallback)  - 오류 메시지를 기록하기 위해 사용합니다.
  */
 const logger =
@@ -85,7 +87,7 @@ const logger =
       })
     : // "development", "test" 환경에서 사용되는 Logger 객체
       createLogger({
-        level: "info",
+        level: "debug",
         format: colorizedFormat,
         defaultMeta: { service: "sparcs-kaist" },
         transports: [consoleTransport],

--- a/src/modules/queues/helpers/createQueue.js
+++ b/src/modules/queues/helpers/createQueue.js
@@ -1,0 +1,31 @@
+const { Queue } = require("bullmq");
+const logger = require("../../logger");
+
+/**
+ * 서버(producer)에서 사용할 BullMQ queue를 생성합니다.
+ * 서버(producer)에서 queue에 추가한 작업은 worker process에 의해 처리됩니다.
+ * 이 함수는 queues/ 내에 있는 함수들에 의해서만 사용돼야 합니다.
+ * @param {string | undefined} redis - Redis 데이터베이스 URI입니다. (예시: redis://localhost:6379).
+ * @param {string} queueName - 서버(producer)와 worker에 의해 사용될 queue의 이름입니다.
+ * @return {Queue | undefined} - BullMQ queue 객체입니다. redis URI가 주어지지 않으면 undefined를 반환합니다.
+ */
+const createQueue = (redis, queueName) => {
+  if (!redis) {
+    logger.warn(
+      "[QUEUES] Redis URI was not provided so the job queue will not work."
+    );
+    return;
+  }
+  const queue = new Queue(queueName, {
+    connection: redis,
+  });
+  queue.on("error", (err) => {
+    logger.error(
+      `[QUEUES] job queue "${queueName}" failed with following error: ${err}`
+    );
+  });
+  logger.info(`[QUEUES] job queue "${queueName}" was created`);
+  return queue;
+};
+
+module.exports = createQueue;

--- a/src/modules/queues/sendNotification.js
+++ b/src/modules/queues/sendNotification.js
@@ -1,0 +1,24 @@
+const createQueue = require("./helpers/createQueue");
+const { redis } = require("../../../loadenv");
+const logger = require("../logger");
+
+const queueName = "notifications";
+const queue = createQueue(redis, queueName);
+
+/**
+ * @param {object} data
+ * @param {Array<string>} data.tokens - 메시지 알림을 받을 기기의 deviceToken들로 구성된 Array입니다.
+ * @param {string} data.type - 메시지 유형으로, "text" | "in" | "out" | "s3img" | "payment" | "settlement" 입니다.
+ * @param {string} data.title - 보낼 메시지의 제목입니다.
+ * @param {string} data.body - 보낼 메시지의 본문입니다.
+ * @param {string?} data.icon - 메시지를 보낸 사람의 프로필 사진 주소입니다.
+ * @param {string?} data.link - 메시지 알림 팝업을 클릭했을 때 이동할 주소입니다.
+ */
+const addToNotificationQueue = async (data) => {
+  const job = await queue?.add(queueName, data);
+  if (job) logger.debug("added a job to sendNotification queue");
+};
+
+module.exports = {
+  addToNotificationQueue,
+};

--- a/src/schedules/index.js
+++ b/src/schedules/index.js
@@ -1,8 +1,10 @@
 const cron = require("node-cron");
+const logger = require("../modules/logger");
 
 const registerSchedules = (app) => {
   cron.schedule("*/5 * * * *", require("./notifyBeforeDepart")(app));
   cron.schedule("*/10 * * * *", require("./notifyAfterArrival")(app));
+  logger.info("[SCHEDULES] cron jobs were registered");
 };
 
 module.exports = registerSchedules;

--- a/src/workers/helpers/createWorker.js
+++ b/src/workers/helpers/createWorker.js
@@ -1,0 +1,48 @@
+const { Worker } = require("bullmq");
+const logger = require("../../modules/logger");
+
+/**
+ * 채팅 알림을 전송하는 BullMQ worker를 생성합니다.
+ *
+ * Redis URI가 주어지지 않으면 worker가 생성되지 않습니다.
+ * 이 함수는 workers/ 내에 있는 함수들에 의해서만 사용돼야 합니다.
+ * @param {string | undefined} redis - Redis 데이터베이스 URI입니다. (예시: redis://localhost:6379).
+ * @param {string} queueName - 서버(producer)와 worker에 의해 사용될 queue의 이름입니다.
+ * @param {Function} processor - 작업을 처리할 함수입니다.
+ * @param {Function} onCompleted - 작업 성공 시 실행될 함수입니다.
+ * @param {Function} onFailed - 작업 실패 시 실행될 함수입니다.
+ * @param {object} retention
+ * @param {number?} retention.completedJobs - queue에 성공한 작업을 몇 개나 저장할 지를 지정합니다(기본: 1,000).
+ * @param {number?} retention.failedJobs - queue에 실패한 작업을 몇 개나 저장할 지를 지정합니다(기본: 5,000).
+ * @return {Worker | undefined} - BullMQ worker입니다. redis URI가 주어지지 않으면 undefined를 반환합니다.
+ */
+const createWorker = (
+  redis,
+  queueName,
+  processor,
+  onCompleted,
+  onFailed,
+  { completedJobs = 1000, failedJobs = 5000 } = {}
+) => {
+  if (!redis) {
+    logger.warn(
+      "[WORKERS] Redis URI was not provided so the worker will not work."
+    );
+    return;
+  }
+  const worker = new Worker(queueName, processor, {
+    connection: redis,
+    removeOnComplete: { count: completedJobs },
+    removeOnFail: { count: failedJobs },
+  });
+  worker.on("completed", onCompleted);
+  worker.on("failed", onFailed);
+  worker.on("error", (err) => {
+    logger.error(
+      `[WORKERS] worker "${queueName}" failed with following error: ${err}`
+    );
+  });
+  return worker;
+};
+
+module.exports = createWorker;

--- a/src/workers/sendNotification.js
+++ b/src/workers/sendNotification.js
@@ -1,0 +1,39 @@
+const createWorker = require("./helpers/createWorker");
+const logger = require("../modules/logger");
+const { initializeApp, sendMessageByTokens } = require("../modules/fcm");
+const { redis } = require("../../loadenv");
+
+// Firebase Admin 초기설정
+initializeApp();
+
+const queueName = "notifications";
+
+/**
+ * @param {object} job
+ * @param {string | undefined} job.id
+ * @param {object} job.data
+ * @param {Array<string>} job.data.tokens - 메시지 알림을 받을 기기의 deviceToken들로 구성된 Array입니다.
+ * @param {string} job.data.type - 메시지 유형으로, "text" | "in" | "out" | "s3img" | "payment" | "settlement" 입니다.
+ * @param {string} job.data.title - 보낼 메시지의 제목입니다.
+ * @param {string} job.data.body - 보낼 메시지의 본문입니다.
+ * @param {string?} job.data.icon - 메시지를 보낸 사람의 프로필 사진 주소입니다.
+ * @param {string?} job.data.link - 메시지 알림 팝업을 클릭했을 때 이동할 주소입니다.
+ */
+const processor = async (job) => {
+  const { tokens, type, title, body, icon, link } = job.data;
+  return await sendMessageByTokens(tokens, type, title, body, icon, link);
+};
+
+const onCompleted = (job, failureCounts) => {
+  logger.debug(`[WORKERS] job id ${job.id} completed; ${failureCounts} failed`);
+};
+
+const onFailed = (job, err) => {
+  logger.error(
+    `[WORKERS] job id ${job.id} failed with following error: ${err}`
+  );
+};
+
+const worker = createWorker(redis, queueName, processor, onCompleted, onFailed);
+
+module.exports = worker;

--- a/worker.js
+++ b/worker.js
@@ -3,12 +3,12 @@ const logger = require("./src/modules/logger");
 // BullMQ worker들을 등록합니다.
 const workers = [require("./src/workers/sendNotification")];
 
-// 오류 발생 시 안전하게 로깅합니다.
+// 오류 발생 시 로깅합니다.
 process.on("uncaughtException", function (err) {
   logger.error(`핸들링되지 않은 예외 발생: ${err}`);
 });
 
-// 오류 발생 시 안전하게 로깅합니다.
+// 오류 발생 시 로깅합니다.
 process.on("unhandledRejection", (err) => {
   logger.error(`Promise에서 핸들링되지 않은 rejection 발생: ${err}`);
 });

--- a/worker.js
+++ b/worker.js
@@ -1,0 +1,22 @@
+const logger = require("./src/modules/logger");
+
+// BullMQ worker들을 등록합니다.
+const workers = [require("./src/workers/sendNotification")];
+
+// 오류 발생 시 안전하게 로깅합니다.
+process.on("uncaughtException", function (err) {
+  logger.error(`핸들링되지 않은 예외 발생: ${err}`);
+});
+
+// 오류 발생 시 안전하게 로깅합니다.
+process.on("unhandledRejection", (err) => {
+  logger.error(`Promise에서 핸들링되지 않은 rejection 발생: ${err}`);
+});
+
+// 프로세스가 종료될 때 worker를 안전하게 종료합니다.
+process.on("SIGINT", async () => {
+  await Promise.all(workers.map(async (worker) => await worker?.close()));
+  logger.info("[WORKERS] worker 프로세스가 종료되었습니다.");
+});
+
+logger.info("[WORKERS] worker 프로세스가 시작되었습니다.");


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #369 
BullMQ job queue를 도입하여 FCM 서버에 알림 전송 요청을 보내는 로직을 비동기적으로 처리합니다.
방 들어가는 데 시간이 너무 오래 걸리는 게 꽤 큰 문제라고 생각해서 일부러 빨리 작업했습니다.

현재는 `emitChatEvent` 함수 내부에서 `sendMessageByTokens` 함수가 완전히 실행될 때까지 기다리기 때문에, taxi 백엔드 서버가 FCM 서버에 요청을 보내고 응답을 받을 때까지 이후 로직들이 실행되지 않는 문제가 발생합니다.

이제 `emitChatEvent` 함수는 실제로 FCM 서버에 요청을 보내는 대신 redis 데이터베이스의 queue에 job을 등록하고, 서버와 분리된 worker 프로세스가 job을 받아 FCM 서버에 요청을 보냅니다.

그 결과 아래 스크린샷과 같이 chat 전송 시 지연 시간이 크게 감소하였습니다.

# Extra info <!-- Answer 'y' or 'n' -->
1. redis가 설치되어 있지 않은 환경에서는 queue와 worker가 생성되지 않도록 작업하였습니다. redis 설치가 되어 있지 않은 경우 redis Docker container를 `pnpm redis:dev` 명령어를 통해 시작하고, `pnpm redis:dev:down` 명령어를 통해 정지시킬 수 있습니다(`REDIS_PATH=redis://127.0.0.1:6379`).
2. dev 서버, prod 서버 배포 시 `worker.js` 파일을 실행하는 `taxi-worker` 컨테이너가 추가돼야 합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
<img width="698" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/46402016/ba351911-254d-466c-ae26-15532975fb84">

원래는 채팅 전송 시 1,000ms 내외가 걸렸습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- https://github.com/sparcs-kaist/taxi-infra/issues/41 : 배포 전에 `taxi-worker` 컨테이너를 생성해야 합니다. draft PR로 작업해 놓았습니다.
- (이벤트 기간이 끝나고) TypeScript 도입 - job 처리할 때에도 job의 타입이 여러 곳에서 동시 사용되고 있어서, TypeScript를 도입하면 타입 재사용성이 높아질 것 같습니다.
