### PR TITLE
#383 `/global-state/create` Endpoint에 이벤트 기간에만 접근 가능하도록 변경

### DIFF
--- a/src/lottery/middlewares/timestampValidator.js
+++ b/src/lottery/middlewares/timestampValidator.js
@@ -1,0 +1,18 @@
+const { eventConfig } = require("../../../loadenv");
+const eventPeriod = eventConfig && {
+  startAt: new Date(eventConfig.startAt),
+  endAt: new Date(eventConfig.endAt),
+};
+
+const timestampValidator = (req, res, next) => {
+  if (
+    req.timestamp >= eventPeriod.endAt ||
+    req.timestamp < eventPeriod.startAt
+  ) {
+    return res.status(400).json({ error: "out of date" });
+  } else {
+    next();
+  }
+};
+
+module.exports = timestampValidator;

--- a/src/lottery/middlewares/timestampValidator.js
+++ b/src/lottery/middlewares/timestampValidator.js
@@ -6,6 +6,7 @@ const eventPeriod = eventConfig && {
 
 const timestampValidator = (req, res, next) => {
   if (
+    !eventPeriod ||
     req.timestamp >= eventPeriod.endAt ||
     req.timestamp < eventPeriod.startAt
   ) {

--- a/src/lottery/routes/docs/quests.js
+++ b/src/lottery/routes/docs/quests.js
@@ -18,7 +18,7 @@ eventsDocs[`${apiPrefix}/instagram/share-event`] = {
               properties: {
                 result: {
                   type: "boolean",
-                  description: "성공 여부. 항상 true입니다.",
+                  description: "성공 여부",
                   example: true,
                 },
               },
@@ -45,7 +45,7 @@ eventsDocs[`${apiPrefix}/instagram/share-purchase`] = {
               required: ["result"],
               properties: {
                 result: {
-                  description: "성공 여부. 항상 true입니다.",
+                  description: "성공 여부",
                   type: "boolean",
                   example: true,
                 },

--- a/src/lottery/routes/globalState.js
+++ b/src/lottery/routes/globalState.js
@@ -7,8 +7,9 @@ const globalStateSchema = require("./docs/globalStateSchema");
 
 router.get("/", globalStateHandlers.getUserGlobalStateHandler);
 
-// 아래의 Endpoint 접근 시 로그인 필요
+// 아래의 Endpoint 접근 시 로그인 및 시각 체크 필요
 router.use(require("../../middlewares/auth"));
+router.use(require("../middlewares/timestampValidator"));
 
 router.post(
   "/create",

--- a/src/lottery/routes/items.js
+++ b/src/lottery/routes/items.js
@@ -8,8 +8,9 @@ const itemsSchema = require("./docs/itemsSchema");
 
 router.get("/list", itemsHandlers.listHandler);
 
-// 아래의 Endpoint 접근 시 로그인 필요
+// 아래의 Endpoint 접근 시 로그인 및 시각 체크 필요
 router.use(require("../../middlewares/auth"));
+router.use(require("../middlewares/timestampValidator"));
 
 router.post(
   "/purchase/:itemId",

--- a/src/lottery/routes/quests.js
+++ b/src/lottery/routes/quests.js
@@ -3,6 +3,7 @@ const router = express.Router();
 const quests = require("../services/quests");
 
 router.use(require("../../middlewares/auth"));
+router.use(require("../middlewares/timestampValidator"));
 
 router.post("/instagram/share-event", quests.instagramEventShareHandler);
 router.post("/instagram/share-purchase", quests.instagramPurchaseShareHandler);

--- a/src/lottery/services/globalState.js
+++ b/src/lottery/services/globalState.js
@@ -4,10 +4,6 @@ const logger = require("../../modules/logger");
 const { isLogin, getLoginInfo } = require("../../modules/auths/login");
 
 const { eventConfig } = require("../../../loadenv");
-const eventPeriod = eventConfig && {
-  startAt: new Date(eventConfig.startAt),
-  endAt: new Date(eventConfig.endAt),
-};
 const contracts =
   eventConfig && require(`../modules/contracts/${eventConfig.mode}`);
 const quests = contracts ? Object.values(contracts.quests) : undefined;
@@ -41,14 +37,6 @@ const getUserGlobalStateHandler = async (req, res) => {
 
 const createUserGlobalStateHandler = async (req, res) => {
   try {
-    if (
-      req.timestamp >= eventPeriod.endAt ||
-      req.timestamp < eventPeriod.startAt
-    )
-      return res
-        .status(400)
-        .json({ error: "GlobalState/Create : out of date" });
-
     let eventStatus = await eventStatusModel
       .findOne({ userId: req.userOid })
       .lean();

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -20,12 +20,6 @@ const updateEventStatus = async (
     }
   );
 
-const { eventConfig } = require("../../../loadenv");
-const eventPeriod = eventConfig && {
-  startAt: new Date(eventConfig.startAt),
-  endAt: new Date(eventConfig.endAt),
-};
-
 const getRandomItem = async (req, depth) => {
   if (depth >= 10) {
     logger.error(`User ${req.userOid} failed to open random box`);
@@ -129,12 +123,6 @@ const purchaseHandler = async (req, res) => {
       return res
         .status(400)
         .json({ error: "Items/Purchase : nonexistent eventStatus" });
-
-    if (
-      req.timestamp >= eventPeriod.endAt ||
-      req.timestamp < eventPeriod.startAt
-    )
-      return res.status(400).json({ error: "Items/Purchase : out of date" });
 
     const { itemId } = req.params;
     const item = await itemModel.findOne({ _id: itemId }).lean();

--- a/src/lottery/services/publicNotice.js
+++ b/src/lottery/services/publicNotice.js
@@ -7,10 +7,6 @@ const {
   publicNoticePopulateOption,
 } = require("../modules/populates/transactions");
 
-const hideNickname = (nickname) => {
-  return `${nickname.toString().slice(0, 2)}${"*".repeat(nickname.length - 2)}`;
-};
-
 const getRecentPurchaceItemListHandler = async (req, res) => {
   try {
     const transactions = (
@@ -22,7 +18,7 @@ const getRecentPurchaceItemListHandler = async (req, res) => {
         .lean()
     ).map(
       ({ userId, item, comment }) =>
-        `${hideNickname(userId.nickname)}님께서 ${item.name}을(를) ${
+        `${userId.nickname}님께서 ${item.name}을(를) ${
           comment.startsWith("송편")
             ? "을(를) 구입하셨습니다."
             : comment.startsWith("랜덤 박스")
@@ -73,7 +69,7 @@ const getTicketLeaderboardHandler = async (req, res) => {
           return null;
         }
         return {
-          nickname: hideNickname(userInfo.nickname),
+          nickname: userInfo.nickname,
           profileImageUrl: userInfo.profileImageUrl,
           ticket1Amount: user.ticket1Amount,
           ticket2Amount: user.ticket2Amount,

--- a/src/lottery/services/quests.js
+++ b/src/lottery/services/quests.js
@@ -1,25 +1,11 @@
 const logger = require("../../modules/logger");
 const contracts = require("../modules/contracts/2023fall");
 
-const { eventConfig } = require("../../../loadenv");
-const eventPeriod = eventConfig && {
-  startAt: new Date(eventConfig.startAt),
-  endAt: new Date(eventConfig.endAt),
-};
-
 /**
  * 인스타그램 스토리에 이벤트를 공유했을 때.
  */
 const instagramEventShareHandler = async (req, res) => {
   try {
-    if (
-      req.timestamp >= eventPeriod.endAt ||
-      req.timestamp < eventPeriod.startAt
-    )
-      return res
-        .status(400)
-        .json({ error: "Quests/Instagram/ShareEvent : out of date" });
-
     const { userOid } = req;
     const contractResult = await contracts.completeEventSharingOnInstagramQuest(
       userOid,
@@ -39,14 +25,6 @@ const instagramEventShareHandler = async (req, res) => {
  */
 const instagramPurchaseShareHandler = async (req, res) => {
   try {
-    if (
-      req.timestamp >= eventPeriod.endAt ||
-      req.timestamp < eventPeriod.startAt
-    )
-      return res
-        .status(400)
-        .json({ error: "Quests/Instagram/SharePurchase : out of date" });
-
     const { userOid } = req;
     const contractResult =
       await contracts.completePurchaseSharingOnInstagramQuest(

--- a/src/lottery/services/quests.js
+++ b/src/lottery/services/quests.js
@@ -1,11 +1,25 @@
 const logger = require("../../modules/logger");
 const contracts = require("../modules/contracts/2023fall");
 
+const { eventConfig } = require("../../../loadenv");
+const eventPeriod = eventConfig && {
+  startAt: new Date(eventConfig.startAt),
+  endAt: new Date(eventConfig.endAt),
+};
+
 /**
  * 인스타그램 스토리에 이벤트를 공유했을 때.
  */
 const instagramEventShareHandler = async (req, res) => {
   try {
+    if (
+      req.timestamp >= eventPeriod.endAt ||
+      req.timestamp < eventPeriod.startAt
+    )
+      return res
+        .status(400)
+        .json({ error: "Quests/Instagram/ShareEvent : out of date" });
+
     const { userOid } = req;
     const contractResult = await contracts.completeEventSharingOnInstagramQuest(
       userOid,
@@ -25,6 +39,14 @@ const instagramEventShareHandler = async (req, res) => {
  */
 const instagramPurchaseShareHandler = async (req, res) => {
   try {
+    if (
+      req.timestamp >= eventPeriod.endAt ||
+      req.timestamp < eventPeriod.startAt
+    )
+      return res
+        .status(400)
+        .json({ error: "Quests/Instagram/SharePurchase : out of date" });
+
     const { userOid } = req;
     const contractResult =
       await contracts.completePurchaseSharingOnInstagramQuest(


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #383 
`/events/2023fall/global-state/create` , `/events/2023fall/quests/instagram/share-event` , `/events/2023fall/quests/instagram/share-purchase` 3개의 Endpoint에 이벤트 기간 전에 HTTP Request를 요청할 경우, 400 BAD REQUEST 오류를 발생시키도록 변경했습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing