### PR TITLE
#387 아이템 관련 API 개선

### DIFF
--- a/src/lottery/modules/quests.js
+++ b/src/lottery/modules/quests.js
@@ -98,7 +98,8 @@ const completeQuest = async (userId, timestamp, quest) => {
     // 5단계: 완료 보상 중 티켓이 있는 경우, 티켓 정보를 가져옵니다.
     const ticket1 =
       quest.reward.ticket1 && (await itemModel.findOne({ itemType: 1 }).lean());
-    if (quest.reward.ticket1 && !ticket1) throw "Fail to find ticket1";
+    if (quest.reward.ticket1 && !ticket1)
+      throw new Error("Fail to find ticket1");
 
     // 6단계: 유저의 EventStatus를 업데이트합니다.
     await eventStatusModel.updateOne(

--- a/src/lottery/routes/docs/itemsSchema.js
+++ b/src/lottery/routes/docs/itemsSchema.js
@@ -44,7 +44,7 @@ const itemBase = {
     stock: {
       type: "number",
       description: "남은 상품 재고. 재고가 있는 경우 1, 없는 경우 0입니다.",
-      example: 10,
+      example: 1,
     },
   },
 };

--- a/src/lottery/routes/docs/itemsSchema.js
+++ b/src/lottery/routes/docs/itemsSchema.js
@@ -43,7 +43,7 @@ const itemBase = {
     },
     stock: {
       type: "number",
-      description: "남은 상품 재고. 0 이상입니다.",
+      description: "남은 상품 재고. 재고가 있는 경우 1, 없는 경우 0입니다.",
       example: 10,
     },
   },

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -112,7 +112,7 @@ const listHandler = async (_, res) => {
     const items = await itemModel
       .find({}, "name imageUrl price description isDisabled stock itemType")
       .lean();
-    res.json({ items: items.map((item) => hideItemStock(item)) });
+    res.json({ items: items.map(hideItemStock) });
   } catch (err) {
     logger.error(err);
     res.status(500).json({ error: "Items/List : internal server error" });

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -20,6 +20,11 @@ const updateEventStatus = async (
     }
   );
 
+const hideItemStock = (item) => {
+  item.stock = item.stock > 0 ? 1 : 0;
+  return item;
+};
+
 const getRandomItem = async (req, depth) => {
   if (depth >= 10) {
     logger.error(`User ${req.userOid} failed to open random box`);
@@ -89,7 +94,7 @@ const getRandomItem = async (req, depth) => {
       userId: req.userOid,
       item: randomItem._id,
       itemType: randomItem.itemType,
-      comment: `랜덤 박스에서 "${randomItem.name}" 1개를 획득했습니다.`,
+      comment: `랜덤박스에서 "${randomItem.name}" 1개를 획득했습니다.`,
     });
     await transaction.save();
 
@@ -109,7 +114,7 @@ const listHandler = async (_, res) => {
     const items = await itemModel
       .find({}, "name imageUrl price description isDisabled stock itemType")
       .lean();
-    res.json({ items });
+    res.json({ items: items.map((item) => hideItemStock(item)) });
   } catch (err) {
     logger.error(err);
     res.status(500).json({ error: "Items/List : internal server error" });
@@ -181,7 +186,7 @@ const purchaseHandler = async (req, res) => {
 
     res.json({
       result: true,
-      reward: randomItem,
+      reward: hideItemStock(randomItem),
     });
   } catch (err) {
     logger.error(err);

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -78,7 +78,7 @@ const getRandomItem = async (req, depth) => {
       )
       .lean();
     if (!newRandomItem) {
-      throw new Error("The item was already sold out");
+      throw new Error(`Item ${randomItem._id.toString()} was already sold out`);
     }
 
     // 2단계: 유저 정보를 업데이트합니다.
@@ -155,7 +155,10 @@ const purchaseHandler = async (req, res) => {
         },
       }
     );
-    if (modifiedCount === 0) throw new Error("The item was already sold out");
+    if (modifiedCount === 0)
+      return res
+        .status(400)
+        .json({ error: "Items/Purchase : item out of stock" });
 
     // 2단계: 유저 정보를 업데이트합니다.
     await updateEventStatus(req.userOid, {

--- a/src/lottery/services/publicNotice.js
+++ b/src/lottery/services/publicNotice.js
@@ -21,7 +21,7 @@ const getRecentPurchaceItemListHandler = async (req, res) => {
         `${userId.nickname}님께서 ${item.name}을(를) ${
           comment.startsWith("송편")
             ? "을(를) 구입하셨습니다."
-            : comment.startsWith("랜덤 박스")
+            : comment.startsWith("랜덤박스")
             ? "을(를) 뽑았습니다."
             : "을(를) 획득하셨습니다."
         }`

--- a/src/lottery/services/transactions.js
+++ b/src/lottery/services/transactions.js
@@ -20,9 +20,7 @@ const getUserTransactionsHandler = async (req, res) => {
       .lean();
     if (transactions)
       res.json({
-        transactions: transactions.map((transaction) =>
-          hideItemStock(transaction)
-        ),
+        transactions: transactions.map(hideItemStock),
       });
     else
       res.status(500).json({ error: "Transactions/ : internal server error" });

--- a/src/lottery/services/transactions.js
+++ b/src/lottery/services/transactions.js
@@ -4,6 +4,13 @@ const {
   transactionPopulateOption,
 } = require("../modules/populates/transactions");
 
+const hideItemStock = (transaction) => {
+  if (transaction.item) {
+    transaction.item.stock = transaction.item.stock > 0 ? 1 : 0;
+  }
+  return transaction;
+};
+
 const getUserTransactionsHandler = async (req, res) => {
   try {
     // userId는 이미 Frontend에서 알고 있고, 중복되는 값이므로 제외합니다.
@@ -13,7 +20,9 @@ const getUserTransactionsHandler = async (req, res) => {
       .lean();
     if (transactions)
       res.json({
-        transactions,
+        transactions: transactions.map((transaction) =>
+          hideItemStock(transaction)
+        ),
       });
     else
       res.status(500).json({ error: "Transactions/ : internal server error" });


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #387 

# Extra info <!-- Answer 'y' or 'n' -->
- 랜덤박스에서 아이템을 뽑는데 실패한 경우, 유저의 상태를 랜덤박스 구입 이전으로 복원하도록 개선했습니다.
- 아이템 재고가 없을 때 항상 400 BAD REQUEST를 전송하도록 변경했습니다.
- 아이템의 `stock` 필드는 0 또는 1로만 반환됩니다. 타입은 여전히 `number` 입니다.
  - 0은 재고가 없는 경우, 1은 재고가 있는 경우입니다.
  - 반영된 곳: `/events/2023fall/items/list` , `/events/2023fall/items/purchase/:itemId` , `/events/2023fall/transactions`

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing
