### PR TITLE
#389 adminJS에 아이템 재고 추가 Action 추가

### DIFF
--- a/src/lottery/index.js
+++ b/src/lottery/index.js
@@ -6,8 +6,13 @@ const {
   transactionModel,
 } = require("./modules/stores/mongo");
 
-const { eventConfig } = require("../../loadenv");
 const { buildResource } = require("../modules/adminResource");
+const {
+  addOneItemStockAction,
+  addFiveItemStockAction,
+} = require("./modules/items");
+
+const { eventConfig } = require("../../loadenv");
 
 // [Routes] 기존 docs 라우터의 docs extend
 eventConfig && require("./routes/docs")();
@@ -24,18 +29,19 @@ lotteryRouter.use("/items", require("./routes/items"));
 lotteryRouter.use("/public-notice", require("./routes/publicNotice"));
 lotteryRouter.use("/quests", require("./routes/quests"));
 
-const resources = [
-  eventStatusModel,
-  questModel,
-  itemModel,
-  transactionModel,
-].map(buildResource());
+const itemResource = buildResource([
+  addOneItemStockAction,
+  addFiveItemStockAction,
+])(itemModel);
+const otherResources = [eventStatusModel, questModel, transactionModel].map(
+  buildResource()
+);
 
 const contracts =
   eventConfig && require(`./modules/contracts/${eventConfig.mode}`);
 
 module.exports = {
   lotteryRouter,
-  resources,
+  resources: [itemResource, ...otherResources],
   contracts,
 };

--- a/src/lottery/modules/items.js
+++ b/src/lottery/modules/items.js
@@ -1,0 +1,66 @@
+const { itemModel } = require("./stores/mongo");
+const { buildRecordAction } = require("../../modules/adminResource");
+const logger = require("../../modules/logger");
+
+const addItemStockActionHandler = (count) => async (req, res, context) => {
+  const itemId = context.record.params._id;
+  const oldStock = context.record.params.stock;
+
+  try {
+    const item = await itemModel
+      .findOneAndUpdate(
+        { _id: itemId },
+        {
+          $inc: {
+            stock: count,
+          },
+        },
+        {
+          new: true,
+        }
+      )
+      .lean();
+    if (!item) throw new Error("Fail to update stock");
+
+    let record = context.record.toJSON(context.currentAdmin);
+    record.params = item;
+
+    return {
+      record,
+      notice: {
+        message: `성공적으로 재고 ${count}개를 추가했습니다. (${oldStock} → ${item.stock})`,
+      },
+      response: {},
+    };
+  } catch (err) {
+    logger.error(err);
+    logger.error(
+      `Fail to process addItemStockActionHandler(${count}) for Item ${itemId}`
+    );
+
+    return {
+      record: context.record.toJSON(context.currentAdmin),
+      notice: {
+        message: `재고를 추가하지 못했습니다. 오류 메세지: ${err}`,
+        type: "error",
+      },
+    };
+  }
+};
+const addItemStockActionLogs = ["update"];
+
+const addOneItemStockAction = buildRecordAction(
+  "addOneItemStock",
+  addItemStockActionHandler(1),
+  addItemStockActionLogs
+);
+const addFiveItemStockAction = buildRecordAction(
+  "addFiveItemStock",
+  addItemStockActionHandler(5),
+  addItemStockActionLogs
+);
+
+module.exports = {
+  addOneItemStockAction,
+  addFiveItemStockAction,
+};

--- a/src/modules/adminResource.js
+++ b/src/modules/adminResource.js
@@ -72,7 +72,7 @@ const recordActionAfterHandler = (actions) => async (res, req, context) => {
   return res;
 };
 
-const recordAction = (actionName, handler, logActions) => ({
+const buildRecordAction = (actionName, handler, logActions) => ({
   actionName,
   actionType: "record",
   component: false,
@@ -100,6 +100,6 @@ const buildResource =
 
 module.exports = {
   generateTarget,
-  recordAction,
+  buildRecordAction,
   buildResource,
 };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #389
adminJS의 Item Resource에 addOneItemStock 및 addFiveItemStock Record Action이 추가되었습니다. 각각 안전하게 아이템의 재고를 1개, 5개씩 추가하는 Action입니다.

현재 각 Action에 대한 HTTP Request가 `GET` 으로 전송되고 있습니다. `POST` 로 전송하는 법을 아시는 분은 알려주시면 감사하겠습니다..!

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing