### PR TITLE
[Bug] trust proxy 설정

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,6 +19,9 @@ connectDatabase();
 app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 
+// reverse proxy가 설정한 헤더를 신뢰합니다.
+app.set("trust proxy", true);
+
 // [Middleware] CORS 설정
 app.use(require("./src/middlewares/cors"));
 

--- a/src/middlewares/limitRate.js
+++ b/src/middlewares/limitRate.js
@@ -2,7 +2,7 @@ const rateLimit = require("express-rate-limit");
 
 const limiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 1500, // Limit each IP to 100 requests per `window` (here, per 15 minutes)
+  max: 1500, // Limit each IP to 1500 requests per `window` (here, per 15 minutes)
   standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
   legacyHeaders: false, // Disable the `X-RateLimit-*` headers
 });


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #396 
Express의 trust proxy 설정이 꺼져 있어, 모든 사용자에 대해 동일한 기준으로 rate limit이 걸리는 현상이 발생했습니다.
모든 IP의 proxy를 신뢰하는 설정을 추가하였습니다(https://expressjs.com/en/guide/behind-proxies.html 참조).

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
