### PR TITLE
#400 정산 및 송금 요청 관련 퀘스트 달성 조건 변경

### DIFF
--- a/src/lottery/modules/contracts/2023fall.js
+++ b/src/lottery/modules/contracts/2023fall.js
@@ -132,16 +132,16 @@ const completeFirstLoginQuest = async (userId, timestamp) => {
  * @usage rooms - commitPaymentHandler, rooms - settlementHandler
  */
 const completePayingAndSendingQuest = async (userId, timestamp, roomObject) => {
+  logger.info(
+    `User ${userId} requested to complete payingAndSendingQuest in Room ${roomObject._id}`
+  );
+
   if (roomObject.part.length < 2) return null;
   if (
     roomObject.time >= eventPeriod.endAt ||
     roomObject.time < eventPeriod.startAt
   )
-    return null;
-
-  logger.info(
-    `User ${userId} requested to complete payingAndSendingQuest in Room ${roomObject._id}`
-  );
+    return null; // 택시 출발 시각이 이벤트 기간 내에 포함되지 않는 경우 퀘스트 완료 요청을 하지 않습니다.
 
   return await completeQuest(userId, timestamp, quests.payingAndSending);
 };
@@ -171,16 +171,16 @@ const completeFirstRoomCreationQuest = async (userId, timestamp) => {
  * @usage rooms - commitPaymentHandler
  */
 const completePayingQuest = async (userId, timestamp, roomObject) => {
+  logger.info(
+    `User ${userId} requested to complete payingQuest in Room ${roomObject._id}`
+  );
+
   if (roomObject.part.length < 2) return null;
   if (
     roomObject.time >= eventPeriod.endAt ||
     roomObject.time < eventPeriod.startAt
   )
-    return null;
-
-  logger.info(
-    `User ${userId} requested to complete payingQuest in Room ${roomObject._id}`
-  );
+    return null; // 택시 출발 시각이 이벤트 기간 내에 포함되지 않는 경우 퀘스트 완료 요청을 하지 않습니다.
 
   return await completeQuest(userId, timestamp, quests.paying);
 };
@@ -198,16 +198,16 @@ const completePayingQuest = async (userId, timestamp, roomObject) => {
  * @usage rooms - settlementHandler
  */
 const completeSendingQuest = async (userId, timestamp, roomObject) => {
+  logger.info(
+    `User ${userId} requested to complete sendingQuest in Room ${roomObject._id}`
+  );
+
   if (roomObject.part.length < 2) return null;
   if (
     roomObject.time >= eventPeriod.endAt ||
     roomObject.time < eventPeriod.startAt
   )
-    return null;
-
-  logger.info(
-    `User ${userId} requested to complete sendingQuest in Room ${roomObject._id}`
-  );
+    return null; // 택시 출발 시각이 이벤트 기간 내에 포함되지 않는 경우 퀘스트 완료 요청을 하지 않습니다.
 
   return await completeQuest(userId, timestamp, quests.sending);
 };

--- a/src/lottery/modules/contracts/2023fall.js
+++ b/src/lottery/modules/contracts/2023fall.js
@@ -1,5 +1,12 @@
 const { buildQuests, completeQuest } = require("../quests");
 const mongoose = require("mongoose");
+const logger = require("../../../modules/logger");
+
+const { eventConfig } = require("../../../../loadenv");
+const eventPeriod = eventConfig && {
+  startAt: new Date(eventConfig.startAt),
+  endAt: new Date(eventConfig.endAt),
+};
 
 /** 전체 퀘스트 목록입니다. */
 const quests = buildQuests({
@@ -117,13 +124,24 @@ const completeFirstLoginQuest = async (userId, timestamp) => {
  * @param {string|mongoose.Types.ObjectId} userId - 퀘스트를 완료한 사용자의 ObjectId입니다.
  * @param {number|Date} timestamp - 퀘스트 완료를 요청한 시각입니다.
  * @param {Object} roomObject - 방의 정보입니다.
+ * @param {mongoose.Types.ObjectId} roomObject._id - 방의 ObjectId입니다.
  * @param {Array<{ user: mongoose.Types.ObjectId }>} roomObject.part - 참여자 목록입니다.
+ * @param {Date} roomObject.time - 출발 시각입니다.
  * @returns {Promise}
  * @description 정산 요청 또는 송금이 이루어질 때마다 호출해 주세요.
  * @usage rooms - commitPaymentHandler, rooms - settlementHandler
  */
 const completePayingAndSendingQuest = async (userId, timestamp, roomObject) => {
   if (roomObject.part.length < 2) return null;
+  if (
+    roomObject.time >= eventPeriod.endAt ||
+    roomObject.time < eventPeriod.startAt
+  )
+    return null;
+
+  logger.info(
+    `User ${userId} requested to complete payingAndSendingQuest in Room ${roomObject._id}`
+  );
 
   return await completeQuest(userId, timestamp, quests.payingAndSending);
 };
@@ -145,13 +163,24 @@ const completeFirstRoomCreationQuest = async (userId, timestamp) => {
  * @param {string|mongoose.Types.ObjectId} userId - 퀘스트를 완료한 사용자의 ObjectId입니다.
  * @param {number|Date} timestamp - 퀘스트 완료를 요청한 시각입니다.
  * @param {Object} roomObject - 방의 정보입니다.
+ * @param {mongoose.Types.ObjectId} roomObject._id - 방의 ObjectId입니다.
  * @param {Array<{ user: mongoose.Types.ObjectId }>} roomObject.part - 참여자 목록입니다.
+ * @param {Date} roomObject.time - 출발 시각입니다.
  * @returns {Promise}
  * @description 정산 요청이 이루어질 때마다 호출해 주세요.
  * @usage rooms - commitPaymentHandler
  */
 const completePayingQuest = async (userId, timestamp, roomObject) => {
   if (roomObject.part.length < 2) return null;
+  if (
+    roomObject.time >= eventPeriod.endAt ||
+    roomObject.time < eventPeriod.startAt
+  )
+    return null;
+
+  logger.info(
+    `User ${userId} requested to complete payingQuest in Room ${roomObject._id}`
+  );
 
   return await completeQuest(userId, timestamp, quests.paying);
 };
@@ -161,13 +190,24 @@ const completePayingQuest = async (userId, timestamp, roomObject) => {
  * @param {string|mongoose.Types.ObjectId} userId - 퀘스트를 완료한 사용자의 ObjectId입니다.
  * @param {number|Date} timestamp - 퀘스트 완료를 요청한 시각입니다.
  * @param {Object} roomObject - 방의 정보입니다.
+ * @param {mongoose.Types.ObjectId} roomObject._id - 방의 ObjectId입니다.
  * @param {Array<{ user: mongoose.Types.ObjectId }>} roomObject.part - 참여자 목록입니다.
+ * @param {Date} roomObject.time - 출발 시각입니다.
  * @returns {Promise}
  * @description 송금이 이루어질 때마다 호출해 주세요.
  * @usage rooms - settlementHandler
  */
 const completeSendingQuest = async (userId, timestamp, roomObject) => {
   if (roomObject.part.length < 2) return null;
+  if (
+    roomObject.time >= eventPeriod.endAt ||
+    roomObject.time < eventPeriod.startAt
+  )
+    return null;
+
+  logger.info(
+    `User ${userId} requested to complete sendingQuest in Room ${roomObject._id}`
+  );
 
   return await completeQuest(userId, timestamp, quests.sending);
 };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #400 
paying, sending, payingAndSending 퀘스트의 완료 조건에 **택시 출발 시각**을 추가하였습니다. 택시 출발 시각이 이벤트 기간 내에 포함되어야만 퀘스트가 완료됩니다. 추가로, 위의 3가지 퀘스트가 완료되는 경우 어떤 방에서 정산/송금 요청이 발생했는지 로그에 기록하도록 개선했습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- #399 