### PR TITLE
#405 reduction in eventStatus query

### DIFF
--- a/src/lottery/middlewares/checkBanned.js
+++ b/src/lottery/middlewares/checkBanned.js
@@ -2,13 +2,12 @@ const { eventStatusModel } = require("../modules/stores/mongo");
 const logger = require("../../modules/logger");
 
 /**
- *
+ * 사용자가 차단 되었는지 여부를 판단합니다.
+ * 차단된 사용자는 이벤트에 한하여 서비스 이용에 제재를 받습니다.
  * @param {*} req eventStatus가 성공적일 경우 req.eventStatus = eventStatus로 들어갑니다.
  * @param {*} res
  * @param {*} next
  * @returns
- * 사용자가 차단 되었는지 여부를 판단합니다.
- * 차단된 사용자는 이벤트에 한하여 서비스 이용에 제재를 받습니다.
  */
 const checkBanned = async (req, res, next) => {
   try {

--- a/src/lottery/middlewares/checkBanned.js
+++ b/src/lottery/middlewares/checkBanned.js
@@ -1,11 +1,25 @@
 const { eventStatusModel } = require("../modules/stores/mongo");
 const logger = require("../../modules/logger");
 
+/**
+ *
+ * @param {*} req eventStatus가 성공적일 경우 req.eventStatus = eventStatus로 들어갑니다.
+ * @param {*} res
+ * @param {*} next
+ * @returns
+ * 사용자가 차단 되었는지 여부를 판단합니다.
+ * 차단된 사용자는 이벤트에 한하여 서비스 이용에 제재를 받습니다.
+ */
 const checkBanned = async (req, res, next) => {
   try {
     const eventStatus = await eventStatusModel
       .findOne({ userId: req.userOid })
       .lean();
+    if (!eventStatus) {
+      return res
+        .status(400)
+        .json({ error: "checkBanned: nonexistent eventStatus" });
+    }
     if (eventStatus.isBanned) {
       return res.status(400).json({ error: "checkBanned: banned user" });
     }

--- a/src/lottery/routes/docs/globalState.js
+++ b/src/lottery/routes/docs/globalState.js
@@ -120,6 +120,11 @@ globalStateDocs[`${apiPrefix}/`] = {
                     },
                   },
                 },
+                isBanned: {
+                  type: "boolean",
+                  description: "해당 유저 제재 대상 여부",
+                  example: false,
+                },
               },
             },
           },

--- a/src/lottery/routes/docs/items.js
+++ b/src/lottery/routes/docs/items.js
@@ -29,6 +29,24 @@ itemsDocs[`${apiPrefix}/list`] = {
           },
         },
       },
+      400: {
+        description:
+          "해당 유저 제재 대상 여부checkBanned에서 이벤트에 동의하지 않은 사람과 제재 대상을 선별합니다.",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                error: {
+                  type: "string",
+                  description: "",
+                  example: "checkBanned: banned user",
+                },
+              },
+            },
+          },
+        },
+      },
     },
   },
 };
@@ -63,6 +81,24 @@ itemsDocs[`${apiPrefix}/purchase/:itemId`] = {
                 },
                 reward: {
                   $ref: "#/components/schemas/rewardItem",
+                },
+              },
+            },
+          },
+        },
+      },
+      400: {
+        description:
+          "checkBanned에서 이벤트에 동의하지 않은 사람과 제재 대상을 선별합니다.",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                error: {
+                  type: "string",
+                  description: "",
+                  example: "checkBanned: banned user",
                 },
               },
             },

--- a/src/lottery/routes/docs/items.js
+++ b/src/lottery/routes/docs/items.js
@@ -29,24 +29,6 @@ itemsDocs[`${apiPrefix}/list`] = {
           },
         },
       },
-      400: {
-        description:
-          "해당 유저 제재 대상 여부checkBanned에서 이벤트에 동의하지 않은 사람과 제재 대상을 선별합니다.",
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                error: {
-                  type: "string",
-                  description: "",
-                  example: "checkBanned: banned user",
-                },
-              },
-            },
-          },
-        },
-      },
     },
   },
 };
@@ -94,6 +76,7 @@ itemsDocs[`${apiPrefix}/purchase/:itemId`] = {
           "application/json": {
             schema: {
               type: "object",
+              required: ["error"],
               properties: {
                 error: {
                   type: "string",

--- a/src/lottery/routes/docs/quests.js
+++ b/src/lottery/routes/docs/quests.js
@@ -36,6 +36,24 @@ eventsDocs[`${apiPrefix}/complete/:questId`] = {
           },
         },
       },
+      400: {
+        description:
+          "checkBanned에서 이벤트에 동의하지 않은 사람과 제재 대상을 선별합니다.",
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                error: {
+                  type: "string",
+                  description: "",
+                  example: "checkBanned: banned user",
+                },
+              },
+            },
+          },
+        },
+      },
     },
   },
 };

--- a/src/lottery/routes/docs/quests.js
+++ b/src/lottery/routes/docs/quests.js
@@ -43,6 +43,7 @@ eventsDocs[`${apiPrefix}/complete/:questId`] = {
           "application/json": {
             schema: {
               type: "object",
+              required: ["error"],
               properties: {
                 error: {
                   type: "string",

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -124,8 +124,7 @@ const listHandler = async (_, res) => {
 
 const purchaseHandler = async (req, res) => {
   try {
-    const eventStatus = await eventStatusModel.findOne({ userId: req.userOid });
-    if (!eventStatus)
+    if (!req.eventStatus)
       return res
         .status(400)
         .json({ error: "Items/Purchase : nonexistent eventStatus" });
@@ -138,7 +137,7 @@ const purchaseHandler = async (req, res) => {
     // 구매 가능 조건: 크레딧이 충분하며, 재고가 남아있으며, 판매 중인 아이템이어야 합니다.
     if (item.isDisabled)
       return res.status(400).json({ error: "Items/Purchase : disabled item" });
-    if (eventStatus.creditAmount < item.price)
+    if (req.eventStatus.creditAmount < item.price)
       return res
         .status(400)
         .json({ error: "Items/Purchase : not enough credit" });

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -124,11 +124,6 @@ const listHandler = async (_, res) => {
 
 const purchaseHandler = async (req, res) => {
   try {
-    if (!req.eventStatus)
-      return res
-        .status(400)
-        .json({ error: "Items/Purchase : nonexistent eventStatus" });
-
     const { itemId } = req.params;
     const item = await itemModel.findOne({ _id: itemId }).lean();
     if (!item)


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #405 
checkBanned 미들웨어를 사용하면, req 객체에 eventStatus를 메모이제이션 하기 때문에 다시 검색할 필요가 없어 검색 쿼리가 줄어듭니다.
# Extra info <!-- Answer 'y' or 'n' -->
JSDocs와 swaggerDocs에 설명 및 400에러에 대한 설명을 적었습니다.
# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
n
# Further Work <!-- PR 이후 개설할 이슈 목록 -->
n