### PR TITLE
#416 추석 이벤트 기간 연장

### DIFF
--- a/loadenv.js
+++ b/loadenv.js
@@ -42,6 +42,6 @@ module.exports = {
     JSON.parse(process.env.EVENT_CONFIG)) || {
     mode: "2023fall",
     startAt: "2023-09-25T00:00:00+09:00",
-    endAt: "2023-10-10T00:00:00+09:00",
+    endAt: "2023-10-12T00:00:00+09:00",
   },
 };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #416 
추석 이벤트 기간을 11일 수요일 23시 59분까지로 연장했습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- `loadenv.js` 의 `eventConfig` 를 `undefined` 로 변경 (이벤트 종료 후)