### PR TITLE
#421 추석 이벤트 관련 코드 비활성화

### DIFF
--- a/loadenv.js
+++ b/loadenv.js
@@ -40,10 +40,5 @@ module.exports = {
   slackWebhookUrl: {
     report: process.env.SLACK_REPORT_WEBHOOK_URL || "", // optional
   },
-  eventConfig: (process.env.EVENT_CONFIG &&
-    JSON.parse(process.env.EVENT_CONFIG)) || {
-    mode: "2023fall",
-    startAt: "2023-09-25T00:00:00+09:00",
-    endAt: "2023-10-12T00:00:00+09:00",
-  },
+  eventConfig: (process.env.EVENT_CONFIG && JSON.parse(process.env.EVENT_CONFIG))
 };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #421
`eventConfig` 의 기본값을 삭제하여, 추석 이벤트 관련 라우터가 동작하지 않도록 했습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing
