### PR TITLE
#426 [Bug] Swagger api 테스트가 작동하지 않음

### DIFF
--- a/src/routes/docs/swaggerDocs.js
+++ b/src/routes/docs/swaggerDocs.js
@@ -9,17 +9,20 @@ const serverList = [
   {
     url: `http://localhost:${port}`,
     description: "local api server",
-    type: "development",
+    development: true,
+    production: false,
   },
   {
     url: "https://taxi.sparcs.org/api",
     description: "taxi main api server",
-    type: "production",
+    development: true,
+    production: true,
   },
   {
     url: "https://taxi.dev.sparcs.org/api",
     description: "taxi dev api server",
-    type: "production",
+    development: true,
+    production: false,
   },
 ];
 
@@ -30,7 +33,7 @@ const swaggerDocs = {
     version: "1.0.0",
   },
   basePath: "/",
-  servers: serverList.filter((server) => server.type === nodeEnv),
+  servers: serverList.filter((server) => server[nodeEnv]),
   tags: [
     {
       name: "locations",

--- a/src/routes/docs/swaggerDocs.js
+++ b/src/routes/docs/swaggerDocs.js
@@ -3,6 +3,25 @@ const reportsDocs = require("./reports");
 const logininfoDocs = require("./logininfo");
 const locationsDocs = require("./locations");
 const usersDocs = require("./users");
+const { port, nodeEnv } = require("../../../loadenv");
+
+const serverList = [
+  {
+    url: `http://localhost:${port}`,
+    description: "local api server",
+    type: "development",
+  },
+  {
+    url: "https://taxi.sparcs.org/api",
+    description: "taxi main api server",
+    type: "production",
+  },
+  {
+    url: "https://taxi.dev.sparcs.org/api",
+    description: "taxi dev api server",
+    type: "production",
+  },
+];
 
 const swaggerDocs = {
   openapi: "3.0.3",
@@ -11,6 +30,7 @@ const swaggerDocs = {
     version: "1.0.0",
   },
   basePath: "/",
+  servers: serverList.filter((server) => server.type === nodeEnv),
   tags: [
     {
       name: "locations",


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #426 

swagger에서 `servers` option을 사용하여 request를 보내고 싶은 base url을 설정 가능합니다.

- development 환경에서는 `http://localhost:port`, `main 서버`, `dev 서버`에 대해 모두 테스트 가능하고,
- production 환경에서는 `main 서버`에 대해서만 테스트 가능하도록 변경하였습니다.