### PR TITLE
#433 [Bug] trust proxy 값이 잘못 설정됨

### DIFF
--- a/app.js
+++ b/app.js
@@ -20,7 +20,7 @@ app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 
 // reverse proxy가 설정한 헤더를 신뢰합니다.
-if (nodeEnv === "production") app.set("trust proxy", 1);
+if (nodeEnv === "production") app.set("trust proxy", 2);
 
 // [Middleware] CORS 설정
 app.use(require("./src/middlewares/cors"));


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #433 
reverse proxy 서버가 2대이므로 trust proxy 값이 2로 설정되어야 합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

없음

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
