### PR TITLE
#441 방 생성 시각의 유효성을 검사하지 않는 버그

### DIFF
--- a/src/routes/docs/rooms.js
+++ b/src/routes/docs/rooms.js
@@ -74,13 +74,18 @@ roomsDocs[`${apiPrefix}/create`] = {
             examples: {
               "출발지와 도착지가 같음": {
                 value: {
-                  error: "Room/create : locations are same",
+                  error: "Rooms/create : locations are same",
                 },
               },
               "현재로부터 2주일보다 이후의 방을 생성": {
                 value: {
                   error:
-                    "Room/create : cannot over 2 weeks on the basis of current Date",
+                    "Rooms/create : cannot over 2 weeks on the basis of current Date",
+                },
+              },
+              "설정된 출발 시각 이후에 방을 생성": {
+                value: {
+                  error: "Rooms/create : invalid timestamp",
                 },
               },
               "존재하지 않는 location Document를 입력": {
@@ -306,12 +311,12 @@ roomsDocs[`${apiPrefix}/join`] = {
               },
               "입력한 시간의 방이 이미 출발함": {
                 value: {
-                  error: "Room/join : The room has already departed",
+                  error: "Rooms/join : The room has already departed",
                 },
               },
               "방의 인원이 모두 찼음": {
                 value: {
-                  error: "Room/join : The room is already full",
+                  error: "Rooms/join : The room is already full",
                 },
               },
             },
@@ -590,12 +595,12 @@ roomsDocs[`${apiPrefix}/search`] = {
             examples: {
               "출발지와 도착지가 같음": {
                 value: {
-                  error: "Room/search : Bad request",
+                  error: "Rooms/search : Bad request",
                 },
               },
               "출발/도착지가 존재하지 않는 장소": {
                 value: {
-                  error: "Room/search : no corresponding locations",
+                  error: "Rooms/search : no corresponding locations",
                 },
               },
             },

--- a/src/services/rooms.js
+++ b/src/services/rooms.js
@@ -20,7 +20,13 @@ const createHandler = async (req, res) => {
   try {
     if (from === to) {
       return res.status(400).json({
-        error: "Room/create : locations are same",
+        error: "Rooms/create : locations are same",
+      });
+    }
+
+    if (req.timestamp > Date.parse(req.body.time)) {
+      return res.status(400).json({
+        error: "Rooms/create : invalid timestamp",
       });
     }
 
@@ -33,7 +39,8 @@ const createHandler = async (req, res) => {
 
     if (createTime.getTime() > maxTime.getTime()) {
       return res.status(400).json({
-        error: "Room/create : cannot over 2 weeks on the basis of current Date",
+        error:
+          "Rooms/create : cannot over 2 weeks on the basis of current Date",
       });
     }
 
@@ -179,7 +186,7 @@ const joinHandler = async (req, res) => {
     // 방이 이미 출발한 경우, 400 오류를 반환합니다.
     if (req.timestamp >= room.time) {
       res.status(400).json({
-        error: "Room/join : The room has already departed",
+        error: "Rooms/join : The room has already departed",
       });
       return;
     }
@@ -187,7 +194,7 @@ const joinHandler = async (req, res) => {
     // 방의 인원이 모두 찬 경우, 400 오류를 반환합니다.
     if (room.part.length + 1 > room.maxPartLength) {
       res.status(400).json({
-        error: "Room/join : The room is already full",
+        error: "Rooms/join : The room is already full",
       });
       return;
     }
@@ -267,7 +274,7 @@ const abortHandler = async (req, res) => {
     } else {
       // room.part에는 user가 있지만 user.ongoingRoom이나 user.doneRoom에는 room이 없는 상황.
       logger.error(
-        `Room/abort: referential integrity error (user: ${user._id}, room: ${room._id})`
+        `Rooms/abort: referential integrity error (user: ${user._id}, room: ${room._id})`
       );
       return res.status(500).json({
         error: "Rooms/abort : internal server error",
@@ -311,7 +318,7 @@ const searchHandler = async (req, res) => {
     // 출발지와 도착지가 같은 경우
     if (from && to && from === to) {
       return res.status(400).json({
-        error: "Room/search : Bad request",
+        error: "Rooms/search : Bad request",
       });
     }
 
@@ -320,7 +327,7 @@ const searchHandler = async (req, res) => {
       const fromLocation = await locationModel.findById(from);
       if (!fromLocation || fromLocation?.isValid === false) {
         return res.status(400).json({
-          error: "Room/search : no corresponding locations",
+          error: "Rooms/search : no corresponding locations",
         });
       }
     }
@@ -328,7 +335,7 @@ const searchHandler = async (req, res) => {
       const toLocation = await locationModel.findById(to);
       if (!toLocation || toLocation?.isValid === false) {
         return res.status(400).json({
-          error: "Room/search : no corresponding locations",
+          error: "Rooms/search : no corresponding locations",
         });
       }
     }


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #441

# Extra info <!-- Answer 'y' or 'n' -->
간단하게 request의 timestamp와 출발 시각을 비교하여, timestamp가 출발 시각 이후인 경우 error를 반환합니다.
아래를 보시면 1:30 이후에 방 생성을 잘 막아주는 걸 알 수 있습니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/sparcs-kaist/taxi-back/assets/68576681/4ed5d8ed-9c93-46e2-9579-15466e06ccd4)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Do something...
