### PR TITLE
#461 메일 전송 SMTP으로 변경

### DIFF
--- a/loadenv.js
+++ b/loadenv.js
@@ -2,7 +2,7 @@
 require("dotenv").config({ path: `./.env.${process.env.NODE_ENV}` });
 
 module.exports = {
-  nodeEnv: process.env.NODE_ENV, // required ("production" or "development" or "test)
+  nodeEnv: process.env.NODE_ENV, // required ("production" or "development" or "test")
   mongo: process.env.DB_PATH, // required
   session: {
     secret: process.env.SESSION_KEY || "TAXI_SESSION_KEY", // optional

--- a/loadenv.js
+++ b/loadenv.js
@@ -2,7 +2,7 @@
 require("dotenv").config({ path: `./.env.${process.env.NODE_ENV}` });
 
 module.exports = {
-  nodeEnv: process.env.NODE_ENV, // required
+  nodeEnv: process.env.NODE_ENV, // required ("production" or "development" or "test)
   mongo: process.env.DB_PATH, // required
   session: {
     secret: process.env.SESSION_KEY || "TAXI_SESSION_KEY", // optional

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "mongoose": "^6.12.0",
     "node-cron": "3.0.2",
     "node-mocks-http": "^1.12.1",
+    "nodemailer": "^6.9.9",
     "querystring": "^0.2.1",
     "redis": "^4.2.0",
     "response-time": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ dependencies:
   node-mocks-http:
     specifier: ^1.12.1
     version: 1.12.2
+  nodemailer:
+    specifier: ^6.9.9
+    version: 6.9.9
   querystring:
     specifier: ^0.2.1
     version: 0.2.1
@@ -6597,6 +6600,11 @@ packages:
 
   /node-releases@2.0.13:
     resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+    dev: false
+
+  /nodemailer@6.9.9:
+    resolution: {integrity: sha512-dexTll8zqQoVJEZPwQAKzxxtFn0qTnjdQTchoU6Re9BUUGBJiOy3YMn/0ShTW6J5M0dfQ1NeDeRTTl4oIWgQMA==}
+    engines: {node: '>=6.0.0'}
     dev: false
 
   /nodemon@3.0.1:

--- a/src/modules/email.js
+++ b/src/modules/email.js
@@ -1,0 +1,137 @@
+const nodemailer = require("nodemailer");
+const logger = require("./logger");
+const { nodeEnv } = require("../../loadenv");
+
+/**
+ * production 환경에서 메일을 전송하기 위해 사용되는 agent입니다.
+ */
+class NodemailerTransport {
+  /** 메일 전송을 위한 agent 객체로, private 필드입니다. */
+  #transporter;
+
+  constructor() {
+    this.#transporter = nodemailer.createTransport({
+      host: "smtp-relay.gmail.com",
+      secure: true,
+      port: 587,
+    });
+  }
+
+  /**
+   * 이메일을 전송합니다.
+   * @param {nodemailer.SendMailOptions} mailOptions - 메일 전송에 필요한 주소, 제목, 본문 등 정보입니다.
+   * @return {Promise<boolean>} 이메일 전송에 성공하면 true를, 실패하면 false를 반환합니다.
+   */
+  async sendMail(mailOptions) {
+    try {
+      await this.#transporter.sendMail(mailOptions);
+      return true;
+    } catch (err) {
+      logger.error(err);
+      return false;
+    }
+  }
+}
+
+/**
+ * development, test 환경에서 메일을 전송하기 위해 사용되는 agent입니다.
+ *
+ * Gmail relay 서버를 사용한 이메일 전송은 production 서버의 ip에서만 허용됩니다.
+ * 그 외 환경에서는 Ethereal mock 서버를 사용해 이메일 전송을 테스트합니다.
+ */
+class MockNodemailerTransport {
+  /** 메일 전송을 위한 agent 객체를 생성하는 Promise로, private 필드입니다. */
+  #transporterPromise;
+
+  constructor() {
+    this.#transporterPromise = null;
+  }
+
+  /**
+   * 이메일 전송을 위한 agent 객체를 생성합니다.
+   * mock 이메일 전송을 위한 테스트 계정을 생성하기 위해 비동기 함수로 작성되었습니다.
+   * @return {Promise<nodemailer.Transporter>} agent 객체를 생성하는 Promise입니다.
+   * @throws {Error} 이메일 전송을 위한 agent 객체 생성에 실패하면 에러를 반환합니다.
+   */
+  async getTransporter() {
+    if (!this.#transporterPromise) {
+      try {
+        this.#transporterPromise = nodemailer
+          .createTestAccount()
+          .then((account) => {
+            return nodemailer.createTransport({
+              host: "smtp.ethereal.email",
+              port: 587,
+              secure: false,
+              auth: {
+                user: account.user,
+                pass: account.pass,
+              },
+            });
+          });
+        return this.#transporterPromise;
+      } catch (err) {
+        logger.error(err);
+        throw err;
+      }
+    } else {
+      return this.#transporterPromise;
+    }
+  }
+
+  /**
+   * 이메일을 전송합니다.
+   * @param {nodemailer.SendMailOptions} mailOptions - 메일 전송에 필요한 주소, 제목, 본문 등 정보입니다.
+   * @return {Promise<boolean>} 이메일 전송에 성공하면 true를, 실패하면 false를 반환합니다.
+   */
+  async sendMail(mailOptions) {
+    try {
+      const transporter = await this.getTransporter();
+      const response = await transporter.sendMail(mailOptions);
+      logger.info(
+        `mock 메일이 전송되었습니다. 미리보기 url: ${nodemailer.getTestMessageUrl(
+          response
+        )}`
+      );
+      return true;
+    } catch (err) {
+      logger.error(err);
+      return false;
+    }
+  }
+}
+
+/** 메일 전송을 위한 agent 객체입니다. */
+const transporter =
+  nodeEnv === "production"
+    ? new NodemailerTransport()
+    : new MockNodemailerTransport();
+
+/**
+ * 이메일을 전송합니다.
+ * @param {string} reportedEmail - 신고를 받은 사용자의 이메일입니다.
+ * @param {object} report - 신고 내용입니다.
+ * @param {string} report.type - 신고 유형입니다. reportTypeMap의 키여야 합니다.
+ * @param {string} html - HTML 형식의 이메일 본문입니다.
+ * @return {Promise<boolean>} 이메일 전송에 성공하면 true를, 실패하면 false를 반환합니다.
+ */
+const sendReportEmail = async (reportedEmail, report, html) => {
+  const reportTypeMap = {
+    "no-settlement": "정산을 하지 않음",
+    "no-show": "택시에 동승하지 않음",
+    "etc-reason": "기타 사유",
+  };
+
+  return transporter.sendMail({
+    from: "taxi@sparcs.org",
+    to: reportedEmail,
+    subject: `[SPARCS TAXI] 신고가 접수되었습니다 (사유: ${
+      reportTypeMap[report.type]
+    })`,
+    html,
+  });
+};
+
+module.exports = {
+  sendReportEmail,
+};

--- a/src/modules/stores/aws.js
+++ b/src/modules/stores/aws.js
@@ -83,37 +83,3 @@ module.exports.foundObject = (filePath, cb) => {
 module.exports.getS3Url = (filePath) => {
   return `${awsEnv.s3Url}${filePath}`;
 };
-
-module.exports.sendReportEmail = (reportedEmail, report, html) => {
-  const reportTypeMap = {
-    "no-settlement": "정산을 하지 않음",
-    "no-show": "택시에 동승하지 않음",
-    "etc-reason": "기타 사유",
-  };
-
-  const params = {
-    Destination: {
-      ToAddresses: [reportedEmail],
-    },
-    Message: {
-      Body: {
-        Html: {
-          Data: html,
-        },
-      },
-      Subject: {
-        Charset: "UTF-8",
-        Data: `[SPARCS TAXI] 신고가 접수되었습니다 (사유: ${reportTypeMap[report.type]})`,
-      },
-    },
-    Source: "taxi.sparcs@gmail.com",
-  };
-
-  ses.sendEmail(params, (err, data) => {
-    if (err) {
-      logger.error("Fail to send email", err);
-    } else {
-      logger.info("Email sent successfully");
-    }
-  });
-};

--- a/src/services/reports.js
+++ b/src/services/reports.js
@@ -4,7 +4,7 @@ const {
   roomModel,
 } = require("../modules/stores/mongo");
 const { reportPopulateOption } = require("../modules/populates/reports");
-const { sendReportEmail } = require("../modules/stores/aws");
+const { sendReportEmail } = require("../modules/email");
 const logger = require("../modules/logger");
 const emailPage = require("../views/emailNoSettlementPage");
 const { notifyToReportChannel } = require("../modules/slackNotification");


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #461
기존에 AWS SES([taxi.sparcs@gmail.com](mailto:taxi.sparcs@gmail.com) 계정)로 전송하는 신고 메일을 SMTP 방식([taxi@sparcs.org](mailto:taxi@sparcs.org))으로 전송하도록 수정합니다.

production 환경에서는 gmail로 이메일을 전송하고, development나 test 환경에서는 [Ethereal](https://ethereal.email/) 서비스를 사용해 mock 이메일을 전송합니다([nodemailer 문서 - Testing SMTP](https://nodemailer.com/smtp/testing/)).

@DoyunShin 도움 주셔서 감사드립니다.. ❤️ 

# Extra info <!-- Answer 'y' or 'n' -->

없음.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="818" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/46402016/db28d087-cb05-4f91-b766-789c18dd932a">
- mock 이메일이 Ethereal 서버로 전송되면, 이메일 미리보기 url이 로그로 기록됩니다.
 
<img width="1211" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/46402016/0acc043e-518a-473f-a8cb-c56bc45bddfe">

- Ethereal 서비스를 사용한 mock 이메일 예시입니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
