### PR TITLE
#463 [Bug] ObjectId 검증 정규식 오타 수정

### DIFF
--- a/src/routes/docs/utils.js
+++ b/src/routes/docs/utils.js
@@ -1,4 +1,4 @@
-const objectIdPattern = `^[a-fA-F\d]{24}$`;
+const objectIdPattern = `^[a-fA-F\\d]{24}$`;
 const roomsPattern = {
   rooms: {
     name: RegExp(


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It fixes #463 

ObjectId 검증 시 사용하는 정규식에 있는 오타를 수정합니다.

(현재) `` `^[a-fA-F\d]{24}$` ``
(수정) `` `^[a-fA-F\\d]{24}$` `` (백슬래시 이스케이프 문제)

**현재 ajv의 validateBody 함수로 `"/reports/create"` API의 입력값을 검증할 때 `objectIdPattern`을 사용하기 때문에, 정상적인 피신고자의 ObjectId(reportedId)가 입력값 검증을 통과하지 못합니다.**
참고로 다른 API에서는 아직 `objectIdPattern`을 바탕으로 입력값을 검증하지 않아서, 신고 생성 시에만 문제가 발생하고 있습니다.

# Extra info <!-- Answer 'y' or 'n' -->

없음.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->

<img width="385" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/46402016/bde35b76-8c0a-4ab5-9fc8-41911918d447">

- 정규식 수정 이후 신고 생성 스크린샷

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 없음.
