### PR TITLE
#474 추천인 퀘스트 설명 업데이트

### DIFF
--- a/src/lottery/modules/contracts.js
+++ b/src/lottery/modules/contracts.js
@@ -89,7 +89,7 @@ const quests = buildQuests({
   eventSharing: {
     name: "너 나랑 ㅌ태태택 (1명)",
     description:
-      "내가 초대한 사람이 Taxi에 가입하여 이벤트에 참여하면 넙죽코인을 드려요. 앱 내의 공유 버튼을 통해 카카오톡으로 초대 문자를 보낼 수 있어요!",
+      "내가 초대한 사람이 Taxi에 가입하여 이벤트에 참여하면 넙죽코인을 드려요. 내가 초대한 사람도 넙죽코인을 받아요. 이벤트 안내 페이지의 <b>이벤트 공유하기</b> 버튼을 통해 카카오톡으로 초대 문자를 보낼 수 있어요!",
     imageUrl:
       "https://sparcs-taxi-prod.s3.ap-northeast-2.amazonaws.com/assets/event-2024spring/quest_eventSharing.png",
     reward: 50,
@@ -98,7 +98,7 @@ const quests = buildQuests({
   eventSharing5: {
     name: "너 나랑 ㅌ태태택 (5명)",
     description:
-      "내가 초대한 사람이 5명이 Taxi에 가입하여 이벤트에 참여하면 넙죽코인을 드려요. 앱 내의 공유 버튼을 통해 카카오톡으로 초대 문자를 보낼 수 있어요!",
+      "내가 초대한 사람이 5명이 Taxi에 가입하여 이벤트에 참여하면 넙죽코인을 드려요. 내가 초대한 사람도 넙죽코인을 받아요. 이벤트 안내 페이지의 <b>이벤트 공유하기</b> 버튼을 통해 카카오톡으로 초대 문자를 보낼 수 있어요!",
     imageUrl:
       "https://sparcs-taxi-prod.s3.ap-northeast-2.amazonaws.com/assets/event-2024spring/quest_eventSharing.png",
     reward: 250,

--- a/src/lottery/services/globalState.js
+++ b/src/lottery/services/globalState.js
@@ -30,7 +30,7 @@ const getUserGlobalStateHandler = async (req, res) => {
     if (!eventStatus)
       return res.json({
         isAgreeOnTermsOfEvent: false,
-        isEligible: checkIsUserEligible(user),
+        isEligible: checkIsUserEligible(user) || !!user?.isAdmin, // 테스트를 위해 관리자인 경우 true로 설정합니다. 하지만 관리자이더라도 이벤트에 참여할 수 없습니다.
         completedQuests: [],
         creditAmount: 0,
         group: 0,


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #474 

이슈에서 언급한대로, 추천인 퀘스트에 대한 설명을 보강하여 사용자들이 쉽게 이해할 수 있도록 개선했습니다. 부가적으로, globalState API에서 관리자의 경우 isEligible 필드를 항상 true를 설정하도록 하여 production 환경에서도 주요 기능을 테스트할 수 있도록 합니다. (단, 이벤트 참여는 불가능합니다.)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing