### PR TITLE
#479 [Bug] 참여자가 1명인 방에 대해서도 어뷰징 감지 스크립트가 반응하는 버그

### DIFF
--- a/src/lottery/schedules/detectAbusingUsers.js
+++ b/src/lottery/schedules/detectAbusingUsers.js
@@ -134,6 +134,7 @@ const detectLessChatUsers = async (period, candidateUserIds) => {
       if (
         period.startAt > room.time ||
         period.endAt <= room.time ||
+        room.part.length < 2 ||
         room.settlementTotal === 0
       )
         return null;


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #479 

새벽 4시마다 작동하는 어뷰징 감지 스크립트에서, 기준 3: "채팅 개수가 5개 미만인 방"의 조건을 잘못 설정하여, 혼자 참여한 방이어도 채팅 개수가 5개 미만이면 어뷰징으로 인식하는 버그가 있었습니다. 이를 이 PR에서 수정하였습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- Nothing