### PR TITLE
#499 [Bug] 메일 전송 안됨

### DIFF
--- a/src/modules/email.js
+++ b/src/modules/email.js
@@ -15,6 +15,9 @@ class NodemailerTransport {
       host: "smtp-relay.gmail.com",
       secure: false,
       port: 587,
+      tls: {
+        rejectUnauthorized: false,
+      },
     });
   }
 


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #499
인증서 관련해서 알 수 없는 이유로 발생하는 SSL 오류로 인해 메일 전송이 안되는 이슈가 있었고, 이 PR에서 해당 현상을 임시적으로 수정하였습니다.