### PR TITLE
#449-2 채팅 빈 문자열 검증

### DIFF
--- a/src/modules/patterns.js
+++ b/src/modules/patterns.js
@@ -15,5 +15,6 @@ module.exports = {
   chat: {
     chatImgType: RegExp("^(image/png|image/jpg|image/jpeg)$"),
     chatSendType: RegExp("^(text|account)$"),
+    chatContent: RegExp("\\S+"), //공백 제외 1글자 이상
   },
 };

--- a/src/modules/patterns.js
+++ b/src/modules/patterns.js
@@ -15,6 +15,7 @@ module.exports = {
   chat: {
     chatImgType: RegExp("^(image/png|image/jpg|image/jpeg)$"),
     chatSendType: RegExp("^(text|account)$"),
-    chatContent: RegExp("\\S+"), //공백 제외 1글자 이상
+    chatContent: RegExp("^\\s{0,}\\S{1}[\\s\\S]{0,}$"), // 왼쪽 공백 제외 최소 1개 문자
+    chatContentLength: RegExp("^[\\s\\S]{1,140}$"), // 공백 포함 최대 140문자
   },
 };

--- a/src/routes/chats.js
+++ b/src/routes/chats.js
@@ -1,6 +1,8 @@
 const express = require("express");
 const { body } = require("express-validator");
 const validator = require("../middlewares/validator");
+const { validateBody } = require("../middlewares/zod");
+const { chatsZod } = require("./docs/schemas/chatsSchema");
 const patterns = require("../modules/patterns");
 
 const router = express.Router();
@@ -47,10 +49,7 @@ router.post(
  */
 router.post(
   "/send",
-  body("roomId").isMongoId(),
-  body("type").matches(patterns.chat.chatSendType),
-  body("content").isString(),
-  validator,
+  validateBody(chatsZod.sendChatHandler),
   chatsHandlers.sendChatHandler
 );
 

--- a/src/routes/docs/schemas/chatsSchema.js
+++ b/src/routes/docs/schemas/chatsSchema.js
@@ -1,0 +1,15 @@
+const { z } = require("zod");
+const { zodToSchemaObject } = require("../utils");
+const { objectId, chat } = require("../../../modules/patterns");
+
+const chatsZod = {
+  sendChatHandler: z.object({
+    roomId: z.string().regex(objectId),
+    type: z.string().regex(chat.chatSendType),
+    content: z.string().regex(chat.chatContent),
+  }),
+};
+
+const chatsSchema = zodToSchemaObject(chatsZod);
+
+module.exports = { chatsZod, chatsSchema };

--- a/src/routes/docs/schemas/chatsSchema.js
+++ b/src/routes/docs/schemas/chatsSchema.js
@@ -6,7 +6,7 @@ const chatsZod = {
   sendChatHandler: z.object({
     roomId: z.string().regex(objectId),
     type: z.string().regex(chat.chatSendType),
-    content: z.string().regex(chat.chatContent),
+    content: z.string().regex(chat.chatContent).regex(chat.chatContentLength),
   }),
 };
 

--- a/src/routes/docs/swaggerDocs.js
+++ b/src/routes/docs/swaggerDocs.js
@@ -1,5 +1,6 @@
 const { reportsSchema } = require("./schemas/reportsSchema");
 const { roomsSchema } = require("./schemas/roomsSchema");
+const { chatsSchema } = require("./schemas/chatsSchema");
 const reportsDocs = require("./reports");
 const logininfoDocs = require("./logininfo");
 const locationsDocs = require("./locations");
@@ -85,6 +86,7 @@ const swaggerDocs = {
     schemas: {
       ...reportsSchema,
       ...roomsSchema,
+      ...chatsSchema,
     },
   },
 };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->
It closes #449 

채팅이 공백이 아닌 문자 하나 이상을 포함 해야만 validate 하도록 정규 표현식을 추가해주었습니다. (patterns.js 참고)
*현재대로라면 빈 문자열을 보낼 시 오류 페이지로 넘어가서 프론트 작업 확인 후 머지되어야 합니다!!
관련 front issue: https://github.com/sparcs-kaist/taxi-front/pull/777

# Extra info <!-- Answer 'y' or 'n' -->

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
<img width="382" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/68576681/641257ba-86c1-4924-8dd0-143ca45ee164">

<img width="426" alt="image" src="https://github.com/sparcs-kaist/taxi-back/assets/68576681/e4f90859-33dd-4f1d-a6b4-9837c441eadc">

# Further Work <!-- PR 이후 개설할 이슈 목록 -->
[Front] 해당 패턴을 사용시 전송 버튼 disable로 변경 및 해당 validation 오류(400) 대처할 수 있어야 함.
