### PR TITLE
#534 [Bug] 네이버 지도 API Credentials가 존재하지 않을 때의 잘못된 동작

### DIFF
--- a/src/modules/fare.js
+++ b/src/modules/fare.js
@@ -32,8 +32,8 @@ const scaledTime = (time) => {
 const initializeDatabase = async () => {
   try {
     if (
-      naverMapApi["X-NCP-APIGW-API-KEY"] === undefined ||
-      naverMapApi["X-NCP-APIGW-API-KEY-ID"] === undefined
+      !naverMapApi["X-NCP-APIGW-API-KEY"] ||
+      !naverMapApi["X-NCP-APIGW-API-KEY-ID"]
     ) {
       logger.error(
         "There is no credential for Naver Map. Taxi Fare functions are disabled."
@@ -126,8 +126,8 @@ const initializeDatabase = async () => {
  */
 const updateTaxiFare = async (sTime, isMajor) => {
   if (
-    naverMapApi["X-NCP-APIGW-API-KEY"] === undefined ||
-    naverMapApi["X-NCP-APIGW-API-KEY-ID"] === undefined
+    !naverMapApi["X-NCP-APIGW-API-KEY"] ||
+    !naverMapApi["X-NCP-APIGW-API-KEY-ID"]
   ) {
     logger.error(
       "There is no credential for Naver Map. Taxi Fare functions are disabled."
@@ -169,8 +169,8 @@ const updateTaxiFare = async (sTime, isMajor) => {
  */
 const callTaxiFare = async (from, to) => {
   if (
-    naverMapApi["X-NCP-APIGW-API-KEY"] === undefined ||
-    naverMapApi["X-NCP-APIGW-API-KEY-ID"] === undefined
+    !naverMapApi["X-NCP-APIGW-API-KEY"] ||
+    !naverMapApi["X-NCP-APIGW-API-KEY-ID"]
   ) {
     logger.error(
       "There is no credential for Naver Map. Taxi Fare functions are disabled."

--- a/src/services/fare.js
+++ b/src/services/fare.js
@@ -21,8 +21,8 @@ const naverMapApi = {
 const getTaxiFareHandler = async (req, res) => {
   try {
     if (
-      naverMapApi["X-NCP-APIGW-API-KEY"] === false ||
-      naverMapApi["X-NCP-APIGW-API-KEY-ID"] === false
+      !naverMapApi["X-NCP-APIGW-API-KEY"] ||
+      !naverMapApi["X-NCP-APIGW-API-KEY-ID"]
     ) {
       return res.status(503).json({
         error: "fare/getTaxiFareHandler: Naver Map API credential not found",


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #534 

Credentials가 존재하지 않을 때 503 에러를 제대로 반환합니다.

# Images or Screenshots <!-- PR 변경 사항에 대한 Screenshot이나 .gif 파일 -->
![image](https://github.com/user-attachments/assets/bd77baa0-acd1-49f6-99be-72f87e993fc2)

# Further Work <!-- PR 이후 개설할 이슈 목록 -->
- Nothing