### PR TITLE
#550 [Bug] FCM 푸시 알림이 수신되지 않는 버그 2

### DIFF
--- a/src/modules/fcm.js
+++ b/src/modules/fcm.js
@@ -201,7 +201,7 @@ const sendMessageByTokens = async (tokens, type, title, body, icon, link) => {
       },
       apns: { payload: { aps: { alert: { title, body } } } },
       android: {
-        ttl: 0,
+        priority: "high",
       },
     };
     const { responses, failureCount } =


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #550
FCM 푸시 알림이 안드로이드 기기에서 가끔 수신되지 않던 버그를 수정합니다.

# Extra info <!-- Answer 'y' or 'n' -->
high priority는 사용을 자제하는 것이 좋으나, 채팅의 경우에는 우선순위가 높다고 판단하여 일단 사용하기로 결정하였습니다. 필요한 경우 차후 논의를 거친 후 수정해도 좋을 것 같습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- #548 에서 언급했듯이, 수신 실패한 디바이스 토큰을 삭제하는 코드에 버그가 있어 수정이 필요합니다.