### PR TITLE
#577 로그인 거부시 거부 사유를 로그에 기록

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -21,7 +21,7 @@ const transUserData = (userData) => {
   const kaistInfo = userData.kaist_info ? JSON.parse(userData.kaist_info) : {};
 
   // info.ku_std_no: 학번
-  // info.isEligible: 카이스트 구성원인지 여부. DB에 저장하지 않음.
+  // info.isEligible: 카이스트 구성원인지 여부
   const info = {
     id: userData.uid,
     sid: userData.sid,
@@ -29,9 +29,10 @@ const transUserData = (userData) => {
     facebook: userData.facebook_id || "",
     twitter: userData.twitter_id || "",
     kaist: kaistInfo?.ku_std_no || "",
+    kaistType: kaistInfo?.employeeType || "", // DB에 저장하지 않음
     sparcs: userData.sparcs_id || "",
     email: kaistInfo?.mail || userData.email,
-    isEligible: userPattern.allowedEmployeeTypes.test(kaistInfo?.employeeType),
+    isEligible: userPattern.allowedEmployeeTypes.test(kaistInfo?.employeeType), // DB에 저장하지 않음
   };
   return info;
 };
@@ -177,8 +178,10 @@ const sparcsssoCallbackHandler = (req, res) => {
       tryLogin(req, res, userData, redirectOrigin, redirectPath);
     } else {
       // 카이스트 구성원이 아닌 경우, SSO 로그아웃 이후, 로그인 실패 URI 로 이동합니다
-      const { id, sid } = userData;
-      logger.info(`Login denied: not a KAIST member (uid: ${id}, sid: ${sid})`);
+      const { id, sid, kaist, kaistType } = userData;
+      logger.info(
+        `Login denied: not a KAIST member (uid: ${id}, sid: ${sid}, kaist: ${kaist}, kaistType: ${kaistType})`
+      );
 
       const redirectUrl = new URL("/login/fail", redirectOrigin).href;
       const ssoLogoutUrl = ssoClient.getLogoutUrl(sid, redirectUrl);

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -164,6 +164,8 @@ const sparcsssoCallbackHandler = (req, res) => {
   }
 
   if (state !== stateForCmp) {
+    logger.info("Login denied: state mismatch");
+
     const redirectUrl = new URL("/login/fail", redirectOrigin).href;
     return res.redirect(redirectUrl);
   }
@@ -175,7 +177,9 @@ const sparcsssoCallbackHandler = (req, res) => {
       tryLogin(req, res, userData, redirectOrigin, redirectPath);
     } else {
       // 카이스트 구성원이 아닌 경우, SSO 로그아웃 이후, 로그인 실패 URI 로 이동합니다
-      const { sid } = userData;
+      const { id, sid } = userData;
+      logger.info(`Login denied: not a KAIST member (uid: ${id}, sid: ${sid})`);
+
       const redirectUrl = new URL("/login/fail", redirectOrigin).href;
       const ssoLogoutUrl = ssoClient.getLogoutUrl(sid, redirectUrl);
       res.redirect(ssoLogoutUrl);


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #577 

# Extra info
Production 환경에서, SPARCS SSO에서 돌아온 후 로그인을 거부하는 이유가 2가지가 있습니다.
- 카이스트 구성원이 아닌 경우
- 콜백으로 돌아오기 전/후의 세션이 다른 경우

위와 같은 경우 로그인 실패 페이지로 리다이렉트를 시키는데, 원인을 로그에 기록하도록 개선하였습니다. 특히, 카이스트 구성원이 아니여서 로그인을 거부하는 경우, UID, SID, 학번, 구성원 타입을 로그에 남기도록 하여 CS에 참고할 수 있도록 하였습니다.

