### PR TITLE
#607 SPARCS SSO에 추가된 kaist_v2_info 필드 대응

### DIFF
--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -17,10 +17,21 @@ const {
 const jwt = require("@/modules/auths/jwt");
 const logger = require("@/modules/logger").default;
 
-const transUserData = (userData) => {
+const transKaistInfo = (userData) => {
   const kaistInfo = userData.kaist_info ? JSON.parse(userData.kaist_info) : {};
+  const kaistInfoV2 = userData.kaist_v2_info
+    ? JSON.parse(userData.kaist_v2_info)
+    : {};
+  return {
+    kaist: kaistInfoV2.std_no || kaistInfo.ku_std_no || "", // 학번 (직원인 경우 빈 문자열)
+    kaistType: kaistInfoV2.socps_cd || kaistInfo.employeeType || "", // 구성원 유형
+    email: kaistInfoV2.email || kaistInfo.mail || "", // 학교 이메일 주소
+  };
+};
 
-  // info.ku_std_no: 학번
+const transUserData = (userData) => {
+  const kaistInfo = transKaistInfo(userData);
+
   // info.isEligible: 카이스트 구성원인지 여부
   const info = {
     id: userData.uid,
@@ -28,11 +39,11 @@ const transUserData = (userData) => {
     name: getFullUsername(userData.first_name, userData.last_name),
     facebook: userData.facebook_id || "",
     twitter: userData.twitter_id || "",
-    kaist: kaistInfo?.ku_std_no || "",
-    kaistType: kaistInfo?.employeeType || "", // DB에 저장하지 않음
+    kaist: kaistInfo.kaist,
+    kaistType: kaistInfo.kaistType, // DB에 저장하지 않음
     sparcs: userData.sparcs_id || "",
-    email: kaistInfo?.mail || userData.email,
-    isEligible: userPattern.allowedEmployeeTypes.test(kaistInfo?.employeeType), // DB에 저장하지 않음
+    email: kaistInfo.email || userData.email,
+    isEligible: userPattern.allowedEmployeeTypes.test(kaistInfo.kaistType), // DB에 저장하지 않음
   };
   return info;
 };


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #607

# Extra info <!-- Answer 'y' or 'n' -->
- 신규 KAIST IAM에서 넘어온 정보는 `kaist_v2_info` 필드에 저장됩니다.
- 기존 KAIST IAM에서 넘어온 정보는 `kaist_info` 필드에 저장됩니다.
- 사용자의 로그인 방법, 시각, 학번 등에 따라 `kaist_v2_info` 와 `kaist_info` 가 둘 다 있을 수도 있고, 하나만 있을 수도 있습니다. 둘 다 존재하는 경우,`kaist_v2_info` 를 우선적으로 조회합니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 프러덕션 환경에서 테스트

