### PR TITLE
#618 방 검색에 위치 좌표 추가

### DIFF
--- a/src/modules/populates/rooms.ts
+++ b/src/modules/populates/rooms.ts
@@ -37,8 +37,14 @@ interface PopulatedParticipant
 }
 
 export interface PopulatedRoom extends Omit<Room, "from" | "to" | "part"> {
-  from: Pick<Location, "_id" | "koName" | "enName"> | null;
-  to: Pick<Location, "_id" | "koName" | "enName"> | null;
+  from: Pick<
+    Location,
+    "_id" | "koName" | "enName" | "latitude" | "longitude"
+  > | null;
+  to: Pick<
+    Location,
+    "_id" | "koName" | "enName" | "latitude" | "longitude"
+  > | null;
   part: PopulatedParticipant[];
 }
 
@@ -46,6 +52,8 @@ interface FormattedLocation {
   _id: string;
   enName: string;
   koName: string;
+  latitude: number;
+  longitude: number;
 }
 
 export interface FormattedRoom {
@@ -91,11 +99,15 @@ export const formatSettlement = (
       _id: roomObject.from!._id!.toString(),
       enName: roomObject.from!.enName,
       koName: roomObject.from!.koName,
+      latitude: roomObject.from!.latitude,
+      longitude: roomObject.from!.longitude,
     },
     to: {
       _id: roomObject.to!._id!.toString(),
       enName: roomObject.to!.enName,
       koName: roomObject.to!.koName,
+      latitude: roomObject.to!.latitude,
+      longitude: roomObject.to!.longitude,
     },
     part: roomObject.part.map((participantSubDocument) => {
       const { _id, name, nickname, profileImageUrl, withdraw, badge } =


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #618 

`room/search` API에서 location을 표현 할 때, 좌표값을 포함합니다.
