### PR TITLE
#676 프로필 이미지 주소를 AWS S3 버킷 주소에서 AWS CloudFront 주소로 업데이트

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "test": "pnpm run sample && cross-env TZ='Asia/Seoul' pnpm run mocha",
     "build": "tsc --project tsconfig.build.json && tsc-alias",
     "clean": "rimraf dist/",
-    "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node dist/index.js",
+    "serve": "cross-env TZ='Asia/Seoul' NODE_ENV=production node dist/src/index.js",
+    "runscript": "cross-env TZ='Asia/Seoul' NODE_ENV=production node",
+    "dev:runscript": "cross-env TZ='Asia/Seoul' NODE_ENV=development ts-node --require tsconfig-paths/register",
     "lint": "pnpm eslint .",
-    "runscript": "cross-env TZ='Asia/Seoul' NODE_ENV=production ts-node --require tsconfig-paths/register",
     "sample": "cross-env NODE_ENV=test ts-node --require tsconfig-paths/register src/sampleGenerator/index.js",
     "dumpDB": "cross-env NODE_ENV=test ts-node --require tsconfig-paths/register src/sampleGenerator/tools/dump.js",
     "restoreDB": "cross-env NODE_ENV=test ts-node --require tsconfig-paths/register src/sampleGenerator/tools/restore.js"

--- a/scripts/profileImageUrlUpdater2.ts
+++ b/scripts/profileImageUrlUpdater2.ts
@@ -1,0 +1,34 @@
+// Issue #676을 해결하기 위한 DB 마이그레이션 스크립트입니다.
+// https://github.com/sparcs-kaist/taxi-back/issues/676
+
+import { userModel, connectDatabase } from "@/modules/stores/mongo";
+import { mongo as mongoUrl } from "@/loadenv";
+
+const database = connectDatabase(mongoUrl);
+
+const main = async () => {
+  try {
+    for await (const user of userModel.find()) {
+      // 이미 변환이 완료된 경우에는 Pass합니다.
+      if (!user.profileImageUrl.startsWith("https://")) continue;
+
+      const profileImageUrl = new URL(user.profileImageUrl);
+      await userModel.findOneAndUpdate(
+        { _id: user._id },
+        {
+          $set: {
+            profileImageUrl: `${profileImageUrl.pathname}${profileImageUrl.search}`,
+          },
+        }
+      );
+    }
+
+    console.log("Done!");
+    process.exit(0);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+};
+
+database.on("open", main);

--- a/src/lottery/services/invites.js
+++ b/src/lottery/services/invites.js
@@ -1,5 +1,6 @@
 const { eventStatusModel } = require("../modules/stores/mongo");
 const { userModel } = require("../../modules/stores/mongo");
+const { resolveS3Url } = require("../../modules/stores/aws");
 const logger = require("@/modules/logger").default;
 
 const { eventConfig } = require("@/loadenv");
@@ -34,7 +35,10 @@ const searchInviterHandler = async (req, res) => {
         .status(500)
         .json({ error: "Invites/search : internal server error" });
 
-    return res.json(inviter);
+    return res.json({
+      ...inviter,
+      profileImageUrl: resolveS3Url(inviter.profileImageUrl),
+    });
   } catch (err) {
     logger.error(err);
     res.status(500).json({ error: "Invites/search : internal server error" });

--- a/src/lottery/services/items.js
+++ b/src/lottery/services/items.js
@@ -4,6 +4,7 @@ const {
   transactionModel,
 } = require("../modules/stores/mongo");
 const { userModel } = require("../../modules/stores/mongo");
+const { resolveS3Url } = require("../../modules/stores/aws");
 const { isLogin, getLoginInfo } = require("../../modules/auths/login");
 const logger = require("@/modules/logger").default;
 
@@ -135,7 +136,7 @@ const getItemLeaderboardHandler = async (req, res) => {
           return {
             userId: user.userId,
             nickname: userInfo.nickname,
-            profileImageUrl: userInfo.profileImageUrl,
+            profileImageUrl: resolveS3Url(userInfo.profileImageUrl),
             amount: user.amount,
             probability: user.probability,
             rank: user.rank,

--- a/src/lottery/services/publicNotice.js
+++ b/src/lottery/services/publicNotice.js
@@ -3,6 +3,7 @@ const {
   transactionModel,
 } = require("../modules/stores/mongo");
 const { userModel } = require("../../modules/stores/mongo");
+const { resolveS3Url } = require("../../modules/stores/aws");
 const { isLogin, getLoginInfo } = require("../../modules/auths/login");
 const logger = require("@/modules/logger").default;
 const {
@@ -55,8 +56,8 @@ const getRecentPurchaceItemListHandler = async (req, res) => {
           comment.startsWith(eventConfig?.credit.name)
             ? "을(를) 구입하셨습니다."
             : comment.startsWith("랜덤박스")
-            ? "을(를) 뽑았습니다."
-            : "을(를) 획득하셨습니다."
+              ? "을(를) 뽑았습니다."
+              : "을(를) 획득하셨습니다."
         }`,
         createAt,
       }));
@@ -142,7 +143,7 @@ const getTicketLeaderboardHandler = async (req, res) => {
         }
         return {
           nickname: userInfo.nickname,
-          profileImageUrl: userInfo.profileImageUrl,
+          profileImageUrl: resolveS3Url(userInfo.profileImageUrl),
           ticket1Amount: user.ticket1Amount,
           ticket2Amount: user.ticket2Amount,
           probability: user.weight / weightSum,
@@ -222,7 +223,7 @@ const getGroupLeaderboardHandler = async (req, res) => {
         return {
           ...group,
           mvpNickname: mvpInfo.nickname,
-          mvpProfileImageUrl: mvpInfo.profileImageUrl,
+          mvpProfileImageUrl: resolveS3Url(mvpInfo.profileImageUrl),
         };
       })
     );

--- a/src/modules/modifyProfile.ts
+++ b/src/modules/modifyProfile.ts
@@ -1,5 +1,4 @@
 import crypto from "crypto";
-import { getS3Url } from "@/modules/stores/aws";
 
 const nouns = [
   "재료역학",
@@ -82,7 +81,7 @@ export const generateNickname = (id: string) => {
 // 기존 프로필 사진의 URI 중 하나를 무작위로 선택해 반환합니다.
 export const generateProfileImageUrl = () => {
   const ridx = crypto.randomInt(defaultProfile.length);
-  return getS3Url(`/profile-img/default/${defaultProfile[ridx]}`);
+  return `/profile-img/default/${defaultProfile[ridx]}`;
 };
 
 // 사용자의 이름과 성을 받아, 한글인지 영어인지에 따라 전체 이름을 반환합니다.

--- a/src/modules/populates/rooms.ts
+++ b/src/modules/populates/rooms.ts
@@ -1,3 +1,4 @@
+import { resolveS3Url } from "@/modules/stores/aws";
 import type {
   User,
   SettlementStatus,
@@ -111,7 +112,7 @@ export const formatSettlement = (
         _id: _id!.toString(),
         name,
         nickname,
-        profileImageUrl,
+        profileImageUrl: resolveS3Url(profileImageUrl),
         withdraw,
         badge,
         isSettlement: includeSettlement ? settlementStatus : undefined,

--- a/src/modules/socket.ts
+++ b/src/modules/socket.ts
@@ -6,6 +6,7 @@ import { Server } from "socket.io";
 import { sessionMiddleware } from "@/middlewares";
 import logger from "@/modules/logger";
 import { getLoginInfo, getBearerToken } from "@/modules/auths/login";
+import { resolveS3Url } from "@/modules/stores/aws";
 import { roomModel, userModel, chatModel } from "@/modules/stores/mongo";
 import { getTokensOfUsers, sendMessageByTokens } from "@/modules/fcm";
 import { corsWhiteList } from "@/loadenv";
@@ -72,7 +73,7 @@ export const transformChatsForRoom = async (chats: PopulatedChat[]) => {
         type: chat.type!,
         authorId: chat.authorId?._id?.toString(),
         authorName: chat.authorId?.nickname,
-        authorProfileUrl: chat.authorId?.profileImageUrl,
+        authorProfileUrl: resolveS3Url(chat.authorId?.profileImageUrl),
         authorIsWithdrew: chat.authorId?.withdraw,
         authorResidence: chat.authorId?.residence,
         content: chat.content,
@@ -229,7 +230,7 @@ export const emitChatEvent = async (
       type,
       name,
       getMessageBody(type, nickname, content),
-      profileImageUrl,
+      resolveS3Url(profileImageUrl),
       `/myroom/${roomId}`
     );
 

--- a/src/modules/stores/aws.ts
+++ b/src/modules/stores/aws.ts
@@ -53,5 +53,16 @@ export const foundObject = async (filePath: string) => {
 
 // function to return full URL of the object
 export const getS3Url = (filePath: string) => {
-  return `${awsEnv.s3Url}${filePath}`;
+  const normalizedPath = filePath.startsWith("/") ? filePath : `/${filePath}`;
+  return `${awsEnv.s3Url}${normalizedPath}`;
 };
+
+// function to resolve S3 URL or return original URL
+export function resolveS3Url(pathOrUrl: string): string;
+export function resolveS3Url(pathOrUrl?: string | null): string | undefined;
+export function resolveS3Url(pathOrUrl?: string | null) {
+  if (pathOrUrl == null) return undefined;
+  if (pathOrUrl === "") return "";
+  if (/^https?:\/\//i.test(pathOrUrl)) return pathOrUrl;
+  return getS3Url(pathOrUrl);
+}

--- a/src/services/logininfo.js
+++ b/src/services/logininfo.js
@@ -1,3 +1,4 @@
+const { resolveS3Url } = require("@/modules/stores/aws");
 const { userModel } = require("@/modules/stores/mongo");
 const { getLoginInfo } = require("@/modules/auths/login");
 const logger = require("@/modules/logger").default;
@@ -26,7 +27,7 @@ const logininfoHandler = async (req, res) => {
       agreeOnTermsOfService: userDetail.agreeOnTermsOfService,
       subinfo: userDetail.subinfo,
       email: userDetail.email,
-      profileImgUrl: userDetail.profileImageUrl,
+      profileImgUrl: resolveS3Url(userDetail.profileImageUrl),
       account: userDetail.account ? userDetail.account : "",
       deviceType: req.session?.isApp ? "app" : "web",
       deviceToken: req.session?.deviceToken,

--- a/src/services/reports.ts
+++ b/src/services/reports.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from "express";
+import { resolveS3Url } from "@/modules/stores/aws";
 import {
   userModel,
   reportModel,
@@ -7,6 +8,7 @@ import {
 } from "@/modules/stores/mongo";
 import {
   reportPopulateOption,
+  type PopulatedReport,
   type ReportPopulatePath,
 } from "@/modules/populates/reports";
 import { sendReportEmail } from "@/modules/email";
@@ -24,6 +26,15 @@ const generateUniqueTrackingId = async () => {
     existingTracking = await emailModel.findOne({ trackingId });
   } while (existingTracking);
   return trackingId;
+};
+
+const resolveProfileImageUrl = (report: PopulatedReport) => {
+  if (report.reportedId?.profileImageUrl) {
+    report.reportedId.profileImageUrl = resolveS3Url(
+      report.reportedId.profileImageUrl
+    );
+  }
+  return report;
 };
 
 export const createHandler: RequestHandler = async (req, res) => {
@@ -102,14 +113,18 @@ export const searchByUserHandler: RequestHandler = async (req, res) => {
     }
 
     const response = {
-      reporting: await reportModel
-        .find({ creatorId: user._id })
-        .limit(1000)
-        .populate<ReportPopulatePath>(reportPopulateOption),
-      reported: await reportModel
-        .find({ reportedId: user._id })
-        .limit(1000)
-        .populate<ReportPopulatePath>(reportPopulateOption),
+      reporting: (
+        await reportModel
+          .find({ creatorId: user._id })
+          .limit(1000)
+          .populate<ReportPopulatePath>(reportPopulateOption)
+      ).map(resolveProfileImageUrl),
+      reported: (
+        await reportModel
+          .find({ reportedId: user._id })
+          .limit(1000)
+          .populate<ReportPopulatePath>(reportPopulateOption)
+      ).map(resolveProfileImageUrl),
     };
     return res.json(response);
   } catch (err) {

--- a/src/services/users.ts
+++ b/src/services/users.ts
@@ -274,7 +274,7 @@ export const editProfileImgDoneHandler: RequestHandler = async (req, res) => {
 
     const userAfter = await userModel.findOneAndUpdate(
       { _id: req.userOid, withdraw: false },
-      { profileImageUrl: aws.getS3Url(`/${key}?token=${req.timestamp}`) },
+      { profileImageUrl: `/${key}?token=${req.timestamp}` },
       { new: true }
     );
     if (!userAfter) {
@@ -284,7 +284,7 @@ export const editProfileImgDoneHandler: RequestHandler = async (req, res) => {
     }
     return res.json({
       result: true,
-      profileImageUrl: userAfter.profileImageUrl,
+      profileImageUrl: aws.resolveS3Url(userAfter.profileImageUrl),
     });
   } catch (err) {
     logger.error(err);

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["src"]
+  "include": ["src", "scripts"]
 }


### PR DESCRIPTION
# Summary <!-- PR 내용에 대한 간단한 요약 및 닫는 이슈 번호 표기. -->

It closes #676 

원래는 user document의 profileImageUrl에 전체 주소가 저장되었는데, 이제는 path + query params만 저장하도록 하고, 클라이언트에 응답을 전송하기 전에 JS 레벨에서 AWS S3 (또는 AWS CF) 주소를 덧붙이도록 변경하였습니다.

# Further Work <!-- PR 이후 개설할 이슈 목록 -->

- 이 PR 머지 후 Dev 서버 / Prod 서버에서 DB 마이그레이션 작업을 한 번 해줘야 합니다.
- 현재 AWS CF 설정에서 캐싱을 임시로 비활성화 해두었는데, 향후 query parameter를 인식(?)하는 형태의 캐싱 정책을 적용해주면 좋을 것 같습니다.
